### PR TITLE
fix: mount custom MySQL/MariaDB config in docker-compose

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -347,16 +347,24 @@ func (g *ComposeGenerator) getMySQLService(svcCfg *config.ServiceConfig, addStan
 		ports = append(ports, fmt.Sprintf("%d:3306", StandardDBPort))
 	}
 
+	volumes := []string{
+		fmt.Sprintf("mysql%s_data:/var/lib/mysql", strings.ReplaceAll(version, ".", "")),
+	}
+
+	// Mount custom MySQL config if it exists
+	customCnf := filepath.Join(g.platform.MageBoxDir(), "docker", "mysql-custom.cnf")
+	if _, err := os.Stat(customCnf); err == nil {
+		volumes = append(volumes, customCnf+":/etc/mysql/conf.d/custom.cnf:ro")
+	}
+
 	return ComposeService{
 		ContainerName: fmt.Sprintf("magebox-mysql-%s", version),
 		Image:         fmt.Sprintf("mysql:%s", version),
 		Ports:         ports,
 		Environment:   env,
-		Volumes: []string{
-			fmt.Sprintf("mysql%s_data:/var/lib/mysql", strings.ReplaceAll(version, ".", "")),
-		},
-		Networks: []string{"magebox"},
-		Restart:  "unless-stopped",
+		Volumes:       volumes,
+		Networks:      []string{"magebox"},
+		Restart:       "unless-stopped",
 		HealthCheck: &HealthCheck{
 			Test:     []string{"CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p" + DefaultDBRootPassword},
 			Interval: "10s",
@@ -385,16 +393,24 @@ func (g *ComposeGenerator) getMariaDBService(svcCfg *config.ServiceConfig, addSt
 		ports = append(ports, fmt.Sprintf("%d:3306", StandardDBPort))
 	}
 
+	volumes := []string{
+		fmt.Sprintf("mariadb%s_data:/var/lib/mysql", strings.ReplaceAll(version, ".", "")),
+	}
+
+	// Mount custom MariaDB config if it exists
+	customCnf := filepath.Join(g.platform.MageBoxDir(), "docker", "mariadb-custom.cnf")
+	if _, err := os.Stat(customCnf); err == nil {
+		volumes = append(volumes, customCnf+":/etc/mysql/conf.d/custom.cnf:ro")
+	}
+
 	return ComposeService{
 		ContainerName: fmt.Sprintf("magebox-mariadb-%s", version),
 		Image:         fmt.Sprintf("mariadb:%s", version),
 		Ports:         ports,
 		Environment:   env,
-		Volumes: []string{
-			fmt.Sprintf("mariadb%s_data:/var/lib/mysql", strings.ReplaceAll(version, ".", "")),
-		},
-		Networks: []string{"magebox"},
-		Restart:  "unless-stopped",
+		Volumes:       volumes,
+		Networks:      []string{"magebox"},
+		Restart:       "unless-stopped",
 		HealthCheck: &HealthCheck{
 			Test:     []string{"CMD", "healthcheck.sh", "--connect", "--innodb_initialized"},
 			Interval: "10s",

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -283,6 +283,74 @@ func TestComposeService_MySQL_WithMemory(t *testing.T) {
 	}
 }
 
+func TestComposeService_MySQL_WithCustomConfig(t *testing.T) {
+	g, tmpDir := setupTestComposeGenerator(t)
+
+	// Create the custom config file
+	cnfDir := filepath.Join(tmpDir, ".magebox", "docker")
+	if err := os.MkdirAll(cnfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cnfPath := filepath.Join(cnfDir, "mysql-custom.cnf")
+	if err := os.WriteFile(cnfPath, []byte("[mysqld]\nskip-log-bin\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svcCfg := &config.ServiceConfig{
+		Enabled: true,
+		Version: "8.0",
+	}
+	svc := g.getMySQLService(svcCfg, false)
+
+	if len(svc.Volumes) != 2 {
+		t.Fatalf("Volumes = %v, want 2 entries (data + custom config)", svc.Volumes)
+	}
+	if !strings.Contains(svc.Volumes[1], "mysql-custom.cnf:/etc/mysql/conf.d/custom.cnf:ro") {
+		t.Errorf("Volumes[1] = %v, want custom cnf mount", svc.Volumes[1])
+	}
+}
+
+func TestComposeService_MySQL_WithoutCustomConfig(t *testing.T) {
+	g, _ := setupTestComposeGenerator(t)
+
+	svcCfg := &config.ServiceConfig{
+		Enabled: true,
+		Version: "8.0",
+	}
+	svc := g.getMySQLService(svcCfg, false)
+
+	if len(svc.Volumes) != 1 {
+		t.Errorf("Volumes = %v, want only data volume when no custom config exists", svc.Volumes)
+	}
+}
+
+func TestComposeService_MariaDB_WithCustomConfig(t *testing.T) {
+	g, tmpDir := setupTestComposeGenerator(t)
+
+	// Create the custom config file
+	cnfDir := filepath.Join(tmpDir, ".magebox", "docker")
+	if err := os.MkdirAll(cnfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cnfPath := filepath.Join(cnfDir, "mariadb-custom.cnf")
+	if err := os.WriteFile(cnfPath, []byte("[mysqld]\nskip-log-bin\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svcCfg := &config.ServiceConfig{
+		Enabled: true,
+		Version: "10.6",
+	}
+	svc := g.getMariaDBService(svcCfg, false)
+
+	if len(svc.Volumes) != 2 {
+		t.Fatalf("Volumes = %v, want 2 entries (data + custom config)", svc.Volumes)
+	}
+	if !strings.Contains(svc.Volumes[1], "mariadb-custom.cnf:/etc/mysql/conf.d/custom.cnf:ro") {
+		t.Errorf("Volumes[1] = %v, want custom cnf mount", svc.Volumes[1])
+	}
+}
+
 func TestComposeService_Redis(t *testing.T) {
 	g, _ := setupTestComposeGenerator(t)
 

--- a/vitepress/services/database.md
+++ b/vitepress/services/database.md
@@ -208,7 +208,7 @@ For large databases, you may need to adjust Docker resources:
 
 ### MySQL Configuration
 
-For production-like performance, you can mount a custom MySQL config:
+You can mount a custom MySQL config file for production-like performance or to control features like binary logging:
 
 ```bash
 # Create custom config
@@ -217,7 +217,16 @@ cat > ~/.magebox/docker/mysql-custom.cnf << EOF
 innodb_buffer_pool_size = 1G
 innodb_log_file_size = 256M
 max_connections = 200
+skip-log-bin
 EOF
+```
+
+For MariaDB, use `~/.magebox/docker/mariadb-custom.cnf` instead.
+
+After creating or modifying the config file, restart MageBox to apply:
+
+```bash
+magebox restart
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Mount ~/.magebox/docker/mysql-custom.cnf (or mariadb-custom.cnf) into the container at /etc/mysql/conf.d/custom.cnf when the file exists, enabling persistent MySQL configuration (e.g. binlog control, InnoDB tuning) that survives docker-compose regeneration.

Closes #5