### PR TITLE
Fix quick install DI error by removing pre-generated env.php 

### DIFF
--- a/cmd/magebox/new.go
+++ b/cmd/magebox/new.go
@@ -1045,6 +1045,13 @@ commands:
 	fmt.Println()
 	cli.PrintInfo("Running Magento setup:install (this may take several minutes)...")
 
+	// Remove env.php before setup:install so Magento generates a clean one.
+	// The Start() step may have created env.php (via ensureEnvPHP) with developer
+	// mode and cache types enabled, which can interfere with DI preference resolution
+	// during schema installation.
+	envPHPPath := filepath.Join(projectDir, "app", "etc", "env.php")
+	os.Remove(envPHPPath)
+
 	// Sanitize database name (hyphens → underscores, matching ensureDatabase)
 	dbName := strings.ReplaceAll(projectName, "-", "_")
 
@@ -1089,6 +1096,12 @@ commands:
 	}
 
 	fmt.Println("  Magento installed " + cli.Success("✓"))
+
+	// Regenerate env.php with MageBox-specific settings (developer mode, Mailpit, etc.)
+	// setup:install creates a basic env.php; we overwrite it with the full template.
+	if err := projectMgr.RegenerateEnvPHP(projectDir); err != nil {
+		cli.PrintWarning("Failed to regenerate env.php: %v", err)
+	}
 
 	// Step 7: Deploy sample data
 	fmt.Println()

--- a/internal/project/lifecycle.go
+++ b/internal/project/lifecycle.go
@@ -697,3 +697,15 @@ func (m *Manager) ensureEnvPHP(projectPath string, cfg *config.Config) error {
 	envGen := newEnvGenerator(projectPath, cfg)
 	return envGen.Generate()
 }
+
+// RegenerateEnvPHP overwrites Magento's app/etc/env.php with the MageBox template,
+// applying settings like developer mode and service configuration.
+func (m *Manager) RegenerateEnvPHP(projectPath string) error {
+	cfg, err := config.LoadFromPath(projectPath)
+	if err != nil {
+		return err
+	}
+
+	envGen := newEnvGenerator(projectPath, cfg)
+	return envGen.Generate()
+}


### PR DESCRIPTION
.. before setup:install

The ensureEnvPHP step during Start() creates env.php with developer mode and cache types enabled before setup:install runs. This causes Magento's ObjectManager to use the Dynamic\Developer factory during schema installation, which fails to resolve DI preferences for InventoryCatalog interfaces.

Remove env.php before setup:install so Magento generates a clean one, then regenerate it afterward with MageBox-specific settings (developer mode, Mailpit).