### PR TITLE
Add IPv6 listen directives to nginx vhost templates on Linux

### DIFF
--- a/internal/nginx/templates/proxy.conf.tmpl
+++ b/internal/nginx/templates/proxy.conf.tmpl
@@ -4,12 +4,18 @@
 {{if .SSLEnabled}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
     return 301 https://$host$request_uri;
 }
 
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     ssl_certificate {{.SSLCertFile}};
@@ -20,6 +26,9 @@ server {
 {{else}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 {{end}}
 

--- a/internal/nginx/templates/vhost-laravel.conf.tmpl
+++ b/internal/nginx/templates/vhost-laravel.conf.tmpl
@@ -13,6 +13,9 @@
 # Standard setup: HTTP redirects to HTTPS, HTTPS handles requests directly
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -26,6 +29,9 @@ server {
 
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -39,6 +45,9 @@ server {
 {{else}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -14,6 +14,9 @@
 # Varnish-enabled: HTTPS proxies to Varnish, HTTP backend handles requests
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -51,6 +54,9 @@ server {
 # Standard setup: HTTP redirects to HTTPS, HTTPS handles requests directly
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -72,6 +78,9 @@ server {
 
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -86,6 +95,9 @@ server {
 {{else}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};

--- a/internal/nginx/vhost.go
+++ b/internal/nginx/vhost.go
@@ -73,6 +73,7 @@ type VhostConfig struct {
 	HTTPPort       int    // 80 on Linux, 8080 on macOS (port forwarding)
 	HTTPSPort      int    // 443 on Linux, 8443 on macOS (port forwarding)
 	BackendPort    int    // Backend port for Varnish (always 8080 when Varnish enabled)
+	EnableIPv6     bool   // true on Linux to add [::]:port listen directives
 	StoreCode      string // Magento store code for multi-store setup (default: "default")
 	MageRunType    string // Magento run type: "store" or "website" (default: "store")
 	AccessLog      string // Path to access log file
@@ -91,6 +92,7 @@ type ProxyConfig struct {
 	SSLKeyFile  string
 	HTTPPort    int
 	HTTPSPort   int
+	EnableIPv6  bool // true on Linux to add [::]:port listen directives
 }
 
 // UpstreamConfig contains data needed to generate an upstream config
@@ -134,9 +136,11 @@ func (g *VhostGenerator) Generate(cfg *config.Config, projectPath string) error 
 	// macOS uses port forwarding (80->8080, 443->8443), Linux uses standard ports
 	httpPort := 80
 	httpsPort := 443
+	enableIPv6 := true
 	if g.platform.Type == platform.Darwin {
 		httpPort = 8080
 		httpsPort = 8443
+		enableIPv6 = false
 	}
 
 	for _, domain := range cfg.Domains {
@@ -163,6 +167,7 @@ func (g *VhostGenerator) Generate(cfg *config.Config, projectPath string) error 
 			HTTPPort:      httpPort,
 			HTTPSPort:     httpsPort,
 			BackendPort:   backendPort,
+			EnableIPv6:    enableIPv6,
 			StoreCode:     domain.GetStoreCode(),
 			MageRunType:   domain.GetMageRunType(),
 			AccessLog:     filepath.Join(logsDir, fmt.Sprintf("%s-access.log", sanitizedDomain)),
@@ -317,9 +322,11 @@ func (g *VhostGenerator) GenerateProxyVhost(cfg ProxyConfig) error {
 	// Set ports based on platform
 	cfg.HTTPPort = 80
 	cfg.HTTPSPort = 443
+	cfg.EnableIPv6 = true
 	if g.platform.Type == platform.Darwin {
 		cfg.HTTPPort = 8080
 		cfg.HTTPSPort = 8443
+		cfg.EnableIPv6 = false
 	}
 
 	// Generate SSL certificate if enabled

--- a/internal/nginx/vhost_test.go
+++ b/internal/nginx/vhost_test.go
@@ -229,6 +229,7 @@ func TestRenderVhost_SSLEnabled(t *testing.T) {
 		SSLKeyFile:    "/path/to/key.pem",
 		HTTPPort:      80,
 		HTTPSPort:     443,
+		EnableIPv6:    true,
 	}
 
 	content, err := g.renderVhost(cfg)
@@ -239,6 +240,8 @@ func TestRenderVhost_SSLEnabled(t *testing.T) {
 	// Should contain SSL configuration (Linux uses port 443)
 	checks := []string{
 		"listen 443 ssl",
+		"listen [::]:443 ssl http2",
+		"listen [::]:80",
 		"ssl_certificate /path/to/cert.pem",
 		"ssl_certificate_key /path/to/key.pem",
 		"return 301 https://",
@@ -248,6 +251,39 @@ func TestRenderVhost_SSLEnabled(t *testing.T) {
 		if !strings.Contains(content, check) {
 			t.Errorf("SSL vhost should contain %q", check)
 		}
+	}
+}
+
+func TestRenderVhost_SSLEnabled_NoIPv6(t *testing.T) {
+	g, tmpDir := setupTestGenerator(t)
+
+	cfg := VhostConfig{
+		ProjectName:   "mystore",
+		Domain:        "mystore.test",
+		DocumentRoot:  "/var/www/mystore/pub",
+		PHPVersion:    "8.2",
+		PHPSocketPath: filepath.Join(tmpDir, ".magebox", "run", "mystore-php8.2.sock"),
+		SSLEnabled:    true,
+		SSLCertFile:   "/path/to/cert.pem",
+		SSLKeyFile:    "/path/to/key.pem",
+		HTTPPort:      8080,
+		HTTPSPort:     8443,
+		EnableIPv6:    false,
+	}
+
+	content, err := g.renderVhost(cfg)
+	if err != nil {
+		t.Fatalf("renderVhost failed: %v", err)
+	}
+
+	// Should NOT contain IPv6 listen directives (macOS uses port forwarding)
+	if strings.Contains(content, "[::]") {
+		t.Error("Vhost with EnableIPv6=false should not contain IPv6 listen directives")
+	}
+
+	// Should still contain IPv4 listen directives
+	if !strings.Contains(content, "listen 8443 ssl") {
+		t.Error("Vhost should contain IPv4 SSL listen directive")
 	}
 }
 

--- a/lib/templates/nginx/proxy.conf.tmpl
+++ b/lib/templates/nginx/proxy.conf.tmpl
@@ -4,12 +4,18 @@
 {{if .SSLEnabled}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
     return 301 https://$host$request_uri;
 }
 
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     ssl_certificate {{.SSLCertFile}};
@@ -20,6 +26,9 @@ server {
 {{else}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 {{end}}
 

--- a/lib/templates/nginx/vhost.conf.tmpl
+++ b/lib/templates/nginx/vhost.conf.tmpl
@@ -14,6 +14,9 @@
 # Varnish-enabled: HTTPS proxies to Varnish, HTTP backend handles requests
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -51,6 +54,9 @@ server {
 # Standard setup: HTTP redirects to HTTPS, HTTPS handles requests directly
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -72,6 +78,9 @@ server {
 
 server {
     listen {{.HTTPSPort}} ssl http2;
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl http2;
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};
@@ -86,6 +95,9 @@ server {
 {{else}}
 server {
     listen {{.HTTPPort}};
+{{- if .EnableIPv6}}
+    listen [::]:{{.HTTPPort}};
+{{- end}}
     server_name {{.Domain}};
 
     access_log {{.AccessLog}};


### PR DESCRIPTION
On Linux, *.localhost domains resolve to ::1 (IPv6) before 127.0.0.1. Without IPv6 listen directives, requests hit the wrong server block, causing confusing errors from other projects.

Adds listen [::]:port directives to all nginx templates (Magento, Laravel, proxy) conditionally on Linux. 

macOS is unaffected as it uses port forwarding.