### PR TITLE
Add auto-discovery of document root directory

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -230,6 +232,39 @@ func (d *Domain) GetRootForType(projectType string) string {
 		return "public"
 	}
 	return "pub"
+}
+
+// webrootCandidates lists common webroot directories in priority order.
+// Magento-style roots come first, then generic ones.
+var webrootCandidates = []string{"pub", "public", "web", "htdocs", "httpdocs"}
+
+// GetRootForProject returns the document root, auto-discovering it from the
+// project directory when no explicit root is configured. It checks for common
+// webroot directories (pub, public, web, htdocs, httpdocs) and returns the
+// first one that exists. Falls back to the project-type default.
+func (d *Domain) GetRootForProject(projectPath, projectType string) string {
+	if d.Root != "" {
+		return d.Root
+	}
+	if detected := discoverRoot(projectPath); detected != "" {
+		return detected
+	}
+	if projectType == ProjectTypeLaravel {
+		return "public"
+	}
+	return "pub"
+}
+
+// discoverRoot checks for common webroot directories inside projectPath
+// and returns the first match, or "" if none exist.
+func discoverRoot(projectPath string) string {
+	for _, candidate := range webrootCandidates {
+		info, err := os.Stat(filepath.Join(projectPath, candidate))
+		if err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // IsSSLEnabled returns whether SSL is enabled, defaulting to true

--- a/internal/nginx/vhost.go
+++ b/internal/nginx/vhost.go
@@ -158,7 +158,7 @@ func (g *VhostGenerator) Generate(cfg *config.Config, projectPath string) error 
 			ProjectPath:   projectPath,
 			ProjectType:   cfg.GetType(),
 			Domain:        domain.Host,
-			DocumentRoot:  filepath.Join(projectPath, domain.GetRootForType(cfg.GetType())),
+			DocumentRoot:  filepath.Join(projectPath, domain.GetRootForProject(projectPath, cfg.GetType())),
 			PHPVersion:    cfg.PHP,
 			PHPSocketPath: g.getPHPSocketPath(cfg.Name, cfg.PHP),
 			SSLEnabled:    domain.IsSSLEnabled(),

--- a/vitepress/guide/project-config.md
+++ b/vitepress/guide/project-config.md
@@ -102,21 +102,22 @@ domains:
     ssl: true               # Enable HTTPS (default: true)
 ```
 
+::: tip Auto-discovery
+When `root` is omitted, MageBox automatically detects the document root by checking for common directories in your project: `pub`, `public`, `web`, `htdocs`, `httpdocs`. The first one found is used. If none exist, it defaults to `pub` (Magento) or `public` (Laravel).
+:::
+
 #### Multiple Domains
 
 ```yaml
 domains:
   - host: mystore.test
-    root: pub
   - host: admin.mystore.test
-    root: pub
   - host: api.mystore.test
-    root: pub
 ```
 
 #### Custom Document Root
 
-For non-standard Magento setups:
+For non-standard setups, set `root` explicitly:
 
 ```yaml
 domains:


### PR DESCRIPTION
When no explicit root is configured for a domain, MageBox now checks for common webroot directories (pub, public, web, htdocs, httpdocs) in the project and uses the first one found. Falls back to the project-type default (pub for Magento, public for Laravel).