### PR TITLE
Add service-specific log tailing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,11 +448,13 @@ magebox redis info                   # Show server info
 ### Log Viewing
 
 ```bash
-magebox logs                         # Show last 20 lines of all logs
-magebox logs -f                      # Follow mode (live tail)
-magebox logs -n 100                  # Show last 100 lines
-magebox logs system.log              # Specific log file
-magebox logs "exception*"            # Wildcard pattern
+magebox logs                         # Magento system.log + exception.log (multitail)
+magebox logs php                     # PHP-FPM error logs
+magebox logs nginx                   # Nginx access/error logs
+magebox logs mysql                   # MySQL/MariaDB container logs
+magebox logs redis                   # Redis container logs
+magebox logs php -f                  # Follow mode (tail -f)
+magebox logs nginx -n 200            # Show last 200 lines
 ```
 
 ### Custom Commands
@@ -681,7 +683,11 @@ magebox config set portainer true
 | `magebox redis shell` | Open Redis CLI |
 | `magebox redis flush` | Flush Redis data |
 | `magebox redis info` | Show Redis info |
-| `magebox logs [-f] [-n N]` | View/tail logs |
+| `magebox logs` | View Magento system/exception logs |
+| `magebox logs php` | View PHP-FPM logs |
+| `magebox logs nginx` | View Nginx access/error logs |
+| `magebox logs mysql` | Stream MySQL/MariaDB logs |
+| `magebox logs redis` | Stream Redis logs |
 | `magebox varnish status` | Show Varnish status and backend health |
 | `magebox varnish enable` | Enable Varnish for current project |
 | `magebox varnish disable` | Disable Varnish for current project |

--- a/cmd/magebox/logs.go
+++ b/cmd/magebox/logs.go
@@ -5,27 +5,86 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"qoliber/magebox/internal/cli"
+	"qoliber/magebox/internal/config"
+	"qoliber/magebox/internal/docker"
 	"qoliber/magebox/internal/platform"
 )
 
+var logsFollowFlag bool
+var logsLinesFlag int
+
 var logsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "View Magento logs with multitail",
-	Long: `Opens system.log and exception.log in a split-screen view using multitail.
+	Short: "View logs for Magento or MageBox services",
+	Long: `View application and service logs.
 
-The logs are displayed in 2 columns:
-  - Left:  system.log
-  - Right: exception.log
+Without a subcommand, opens Magento system.log and exception.log in multitail.
 
-Press 'q' to quit, 'b' to scroll back in history.`,
+Service-specific logs:
+  magebox logs php      # PHP-FPM error logs
+  magebox logs nginx    # Nginx access/error logs
+  magebox logs mysql    # MySQL/MariaDB container logs
+  magebox logs redis    # Redis container logs
+
+Press 'q' to quit, 'b' to scroll back in history (multitail views).
+Use -f to follow (tail) file-based logs, or Ctrl+C to stop container log streams.`,
 	RunE: runLogs,
 }
 
+var logsPhpCmd = &cobra.Command{
+	Use:   "php",
+	Short: "View PHP-FPM logs",
+	Long: `Tails PHP-FPM error logs for the current project.
+
+Log files are located in ~/.magebox/logs/php-fpm/.
+Use -f to follow the log output in real-time.`,
+	RunE: runLogsPhp,
+}
+
+var logsNginxCmd = &cobra.Command{
+	Use:   "nginx",
+	Short: "View Nginx logs",
+	Long: `Opens Nginx access and error logs for the current project in a split-screen view.
+
+Log files are located in ~/.magebox/logs/nginx/.
+Without -f, uses multitail for split-screen viewing.
+With -f, tails all matching log files.`,
+	RunE: runLogsNginx,
+}
+
+var logsMysqlCmd = &cobra.Command{
+	Use:   "mysql",
+	Short: "View MySQL/MariaDB logs",
+	Long: `Streams logs from the MySQL or MariaDB Docker container.
+
+Uses docker compose logs to stream the container output.
+Press Ctrl+C to stop.`,
+	RunE: runLogsMysql,
+}
+
+var logsRedisCmd = &cobra.Command{
+	Use:   "redis",
+	Short: "View Redis logs",
+	Long: `Streams logs from the Redis Docker container.
+
+Uses docker compose logs to stream the container output.
+Press Ctrl+C to stop.`,
+	RunE: runLogsRedis,
+}
+
 func init() {
+	logsCmd.PersistentFlags().BoolVarP(&logsFollowFlag, "follow", "f", false, "Follow log output (tail -f)")
+	logsCmd.PersistentFlags().IntVarP(&logsLinesFlag, "lines", "n", 100, "Number of lines to show")
+
+	logsCmd.AddCommand(logsPhpCmd)
+	logsCmd.AddCommand(logsNginxCmd)
+	logsCmd.AddCommand(logsMysqlCmd)
+	logsCmd.AddCommand(logsRedisCmd)
 	rootCmd.AddCommand(logsCmd)
 }
 
@@ -83,6 +142,234 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		systemLog,
 		exceptionLog,
 	)
+	multitailCmd.Stdin = os.Stdin
+	multitailCmd.Stdout = os.Stdout
+	multitailCmd.Stderr = os.Stderr
+
+	return multitailCmd.Run()
+}
+
+func runLogsPhp(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	logsDir := filepath.Join(p.MageBoxDir(), "logs", "php-fpm")
+
+	// Find log files matching the project name
+	logFiles := findProjectLogFiles(logsDir, cfg.Name)
+	if len(logFiles) == 0 {
+		cli.PrintError("No PHP-FPM log files found for project %s", cli.Highlight(cfg.Name))
+		cli.PrintInfo("Log directory: %s", cli.Path(logsDir))
+		cli.PrintInfo("PHP-FPM logs are created when the project is started")
+		return nil
+	}
+
+	if logsFollowFlag {
+		return tailFiles(logFiles)
+	}
+
+	// Use multitail if available, otherwise fall back to tail
+	if platform.CommandExists("multitail") {
+		return multitailFiles(logFiles)
+	}
+	return tailFiles(logFiles)
+}
+
+func runLogsNginx(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	logsDir := filepath.Join(p.MageBoxDir(), "logs", "nginx")
+
+	// Find log files matching the project domains
+	var logFiles []string
+	for _, domain := range cfg.Domains {
+		accessLog := filepath.Join(logsDir, fmt.Sprintf("%s-access.log", domain.Host))
+		errorLog := filepath.Join(logsDir, fmt.Sprintf("%s-error.log", domain.Host))
+
+		if _, err := os.Stat(accessLog); err == nil {
+			logFiles = append(logFiles, accessLog)
+		}
+		if _, err := os.Stat(errorLog); err == nil {
+			logFiles = append(logFiles, errorLog)
+		}
+	}
+
+	if len(logFiles) == 0 {
+		cli.PrintError("No Nginx log files found for project %s", cli.Highlight(cfg.Name))
+		cli.PrintInfo("Log directory: %s", cli.Path(logsDir))
+		cli.PrintInfo("Nginx logs are created when the project is started")
+		return nil
+	}
+
+	if logsFollowFlag {
+		return tailFiles(logFiles)
+	}
+
+	// Use multitail if available for split-screen view
+	if platform.CommandExists("multitail") {
+		return multitailFiles(logFiles)
+	}
+	return tailFiles(logFiles)
+}
+
+func runLogsMysql(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	db, err := getDbInfo(cfg)
+	if err != nil {
+		cli.PrintError("%v", err)
+		return nil
+	}
+
+	composeGen := docker.NewComposeGenerator(p)
+	composeFile := composeGen.ComposeFilePath()
+
+	// Determine compose service name
+	serviceName := fmt.Sprintf("%s%s", db.Type, strings.ReplaceAll(db.Version, ".", ""))
+
+	return streamDockerLogs(composeFile, serviceName, db.Type)
+}
+
+func runLogsRedis(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	if !cfg.Services.HasRedis() {
+		cli.PrintError("Redis is not configured in %s", config.ConfigFileName)
+		return nil
+	}
+
+	composeGen := docker.NewComposeGenerator(p)
+	composeFile := composeGen.ComposeFilePath()
+
+	return streamDockerLogs(composeFile, "redis", "Redis")
+}
+
+// streamDockerLogs streams logs from a Docker Compose service
+func streamDockerLogs(composeFile, serviceName, displayName string) error {
+	logsArgs := []string{"logs"}
+	logsArgs = append(logsArgs, "--tail", fmt.Sprintf("%d", logsLinesFlag))
+	logsArgs = append(logsArgs, "-f")
+	logsArgs = append(logsArgs, serviceName)
+
+	cli.PrintInfo("Streaming %s logs (Ctrl+C to stop)...", displayName)
+	fmt.Println()
+
+	logCmd := docker.BuildComposeCmd(composeFile, logsArgs...)
+	logCmd.Stdin = os.Stdin
+	logCmd.Stdout = os.Stdout
+	logCmd.Stderr = os.Stderr
+
+	return logCmd.Run()
+}
+
+// findProjectLogFiles finds log files in a directory matching a project name prefix
+func findProjectLogFiles(dir, projectName string) []string {
+	var files []string
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return files
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), projectName) && strings.HasSuffix(entry.Name(), ".log") {
+			files = append(files, filepath.Join(dir, entry.Name()))
+		}
+	}
+
+	return files
+}
+
+// tailFiles tails one or more files using tail -f
+func tailFiles(files []string) error {
+	args := []string{"-f", "-n", fmt.Sprintf("%d", logsLinesFlag)}
+	args = append(args, files...)
+
+	cli.PrintInfo("Tailing %d log file(s) (Ctrl+C to stop)...", len(files))
+	for _, f := range files {
+		fmt.Printf("  %s\n", cli.Path(f))
+	}
+	fmt.Println()
+
+	tailCmd := exec.Command("tail", args...)
+	tailCmd.Stdin = os.Stdin
+	tailCmd.Stdout = os.Stdout
+	tailCmd.Stderr = os.Stderr
+
+	return tailCmd.Run()
+}
+
+// multitailFiles opens files in multitail split-screen view
+func multitailFiles(files []string) error {
+	cli.PrintInfo("Opening %d log file(s) in multitail...", len(files))
+	for _, f := range files {
+		fmt.Printf("  %s\n", cli.Path(f))
+	}
+	fmt.Println("Press 'q' to quit, 'b' to scroll back")
+	fmt.Println()
+
+	args := []string{"-n", "200", "-m", "500"}
+	// -s splits into columns; multitail requires the value to be >= 2
+	if len(files) >= 2 {
+		args = append(args, "-s", "2")
+	}
+	args = append(args, files...)
+
+	multitailCmd := exec.Command("multitail", args...)
 	multitailCmd.Stdin = os.Stdin
 	multitailCmd.Stdout = os.Stdout
 	multitailCmd.Stderr = os.Stderr

--- a/vitepress/guide/logs.md
+++ b/vitepress/guide/logs.md
@@ -146,11 +146,47 @@ php -r "throw new Exception('Test error');"
 
 Press `Ctrl+C` to stop watching for new reports.
 
-## Nginx Logs
+## Service-Specific Logs
 
-MageBox stores per-domain nginx logs for easy debugging:
+MageBox provides dedicated log commands for each service, making it easy to debug issues without hunting for log file paths.
 
-### Location
+### Global Flags
+
+All `magebox logs` subcommands support these flags:
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--follow` | Follow log output (tail -f) |
+| `-n`, `--lines` | Number of lines to show (default: 100) |
+
+### `magebox logs php`
+
+View PHP-FPM error logs for the current project.
+
+```bash
+magebox logs php        # View in multitail (or tail if unavailable)
+magebox logs php -f     # Follow mode
+magebox logs php -n 50  # Show last 50 lines
+```
+
+Log files are located in `~/.magebox/logs/php-fpm/` and are matched by project name:
+
+```
+~/.magebox/logs/php-fpm/
+├── mystore-error.log
+└── mystore-slow.log
+```
+
+### `magebox logs nginx`
+
+View Nginx access and error logs for the current project's domains.
+
+```bash
+magebox logs nginx        # View in multitail split-screen
+magebox logs nginx -f     # Follow mode
+```
+
+Log files are located in `~/.magebox/logs/nginx/` with per-domain files:
 
 ```
 ~/.magebox/logs/nginx/
@@ -160,22 +196,9 @@ MageBox stores per-domain nginx logs for easy debugging:
 └── api.mystore.test-error.log
 ```
 
-Each domain configured in your project gets its own access and error log.
+When multiple domains are configured, multitail shows them in a split-screen layout.
 
-### Viewing Nginx Logs
-
-```bash
-# Watch access log for a specific domain
-tail -f ~/.magebox/logs/nginx/mystore.test-access.log
-
-# Watch error log for a specific domain
-tail -f ~/.magebox/logs/nginx/mystore.test-error.log
-
-# Watch all nginx logs
-tail -f ~/.magebox/logs/nginx/*.log
-```
-
-### Common Errors
+#### Common Nginx Errors
 
 | Error | Likely Cause |
 |-------|-------------|
@@ -183,9 +206,35 @@ tail -f ~/.magebox/logs/nginx/*.log
 | `404 Not Found` | Wrong document root (should be `pub`) |
 | `connect() failed` | PHP-FPM socket not found |
 
-## Combining Both Commands
+### `magebox logs mysql`
 
-For comprehensive debugging, run both commands in separate terminal tabs:
+Stream logs from the MySQL or MariaDB Docker container.
+
+```bash
+magebox logs mysql          # Stream container logs
+magebox logs mysql -n 200   # Show last 200 lines
+```
+
+Uses `docker compose logs` under the hood. Automatically detects whether your project uses MySQL or MariaDB. Press `Ctrl+C` to stop.
+
+### `magebox logs redis`
+
+Stream logs from the Redis Docker container.
+
+```bash
+magebox logs redis          # Stream container logs
+magebox logs redis -n 200   # Show last 200 lines
+```
+
+Uses `docker compose logs` under the hood. Press `Ctrl+C` to stop.
+
+::: tip
+Redis must be configured in your `.magebox.yaml` for this command to work.
+:::
+
+## Combining Commands
+
+For comprehensive debugging, run multiple log commands in separate terminal tabs:
 
 **Terminal 1:**
 ```bash
@@ -194,13 +243,18 @@ magebox logs
 
 **Terminal 2:**
 ```bash
+magebox logs php -f
+```
+
+**Terminal 3:**
+```bash
 magebox report
 ```
 
 This gives you:
-- Real-time log monitoring (system + exceptions)
+- Real-time Magento log monitoring (system + exceptions)
+- PHP-FPM error tracking
 - Instant notification of crash reports
-- Full context when debugging issues
 
 ## Tips
 
@@ -224,9 +278,9 @@ tail -f var/log/system.log | grep "Vendor_Module"
 | `var/log/exception.log` | PHP exceptions and stack traces |
 | `var/log/debug.log` | Debug-level messages (when enabled) |
 | `var/report/*` | Unhandled exception reports with unique IDs |
-| `~/.magebox/logs/nginx/{domain}-access.log` | Per-domain nginx access logs |
-| `~/.magebox/logs/nginx/{domain}-error.log` | Per-domain nginx error logs |
-| `~/.magebox/logs/php-fpm/{project}.log` | PHP-FPM error logs per project |
+| `~/.magebox/logs/nginx/{domain}-access.log` | Per-domain nginx access logs (`magebox logs nginx`) |
+| `~/.magebox/logs/nginx/{domain}-error.log` | Per-domain nginx error logs (`magebox logs nginx`) |
+| `~/.magebox/logs/php-fpm/{project}-error.log` | PHP-FPM error logs per project (`magebox logs php`) |
 
 ### Cleaning Up Reports
 

--- a/vitepress/reference/commands.md
+++ b/vitepress/reference/commands.md
@@ -754,6 +754,59 @@ Requires `multitail`. Run `magebox bootstrap` to install it.
 
 ---
 
+### `magebox logs php`
+
+View PHP-FPM error logs for the current project.
+
+```bash
+magebox logs php        # View in multitail or tail
+magebox logs php -f     # Follow mode (tail -f)
+magebox logs php -n 50  # Show last 50 lines
+```
+
+Finds log files matching the project name in `~/.magebox/logs/php-fpm/`. Uses multitail when available, falls back to `tail`.
+
+---
+
+### `magebox logs nginx`
+
+View Nginx access and error logs for the current project.
+
+```bash
+magebox logs nginx        # View in multitail split-screen
+magebox logs nginx -f     # Follow mode
+```
+
+Shows per-domain access and error logs from `~/.magebox/logs/nginx/`. With multiple domains, multitail displays them in a split-screen layout.
+
+---
+
+### `magebox logs mysql`
+
+Stream MySQL/MariaDB Docker container logs.
+
+```bash
+magebox logs mysql          # Stream logs (Ctrl+C to stop)
+magebox logs mysql -n 200   # Show last 200 lines
+```
+
+Auto-detects whether the project uses MySQL or MariaDB.
+
+---
+
+### `magebox logs redis`
+
+Stream Redis Docker container logs.
+
+```bash
+magebox logs redis          # Stream logs (Ctrl+C to stop)
+magebox logs redis -n 200   # Show last 200 lines
+```
+
+Requires Redis to be configured in `.magebox.yaml`.
+
+---
+
 ### `magebox report`
 
 Watch for Magento error reports.

--- a/vitepress/roadmap.md
+++ b/vitepress/roadmap.md
@@ -12,6 +12,7 @@ The following features have been implemented:
 
 | Feature | Version | Description |
 |---------|---------|-------------|
+| **Service-Specific Logs** | v1.3.0 | `magebox logs php/nginx/mysql/redis` for per-service log tailing |
 | **Isolated PHP-FPM** | v1.2.0 | `magebox php isolate` for dedicated PHP-FPM masters per project |
 | IPv6 DNS Support | v1.2.0 | dnsmasq responds to AAAA queries, fixing 30s DNS delays |
 | PHP System Commands | v1.2.0 | `magebox php system` for PHP_INI_SYSTEM settings management |
@@ -39,17 +40,6 @@ The following features have been implemented:
 | Multi-Domain Support | v0.7.1 | Multiple domains per project with store codes |
 
 ## Planned Features
-
-### Service-Specific Log Tailing
-
-Dedicated log commands for each service:
-
-```bash
-magebox logs php      # PHP-FPM logs
-magebox logs nginx    # Nginx access/error logs
-magebox logs mysql    # MySQL query logs
-magebox logs redis    # Redis logs
-```
 
 ### Performance Profiling Dashboard
 


### PR DESCRIPTION
Implement `magebox logs php/nginx/mysql/redis` subcommands for viewing per-service logs. PHP-FPM and Nginx tail local log files with multitail support, while MySQL and Redis stream Docker container logs.