### PR TITLE
Add phpMyAdmin as built-in service

### DIFF
--- a/cmd/magebox/bootstrap.go
+++ b/cmd/magebox/bootstrap.go
@@ -964,6 +964,9 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 	if globalCfg.Portainer {
 		fmt.Printf("  Portainer:    %s\n", cli.URL("http://localhost:9000"))
 	}
+	if globalCfg.PhpMyAdmin {
+		fmt.Printf("  phpMyAdmin:   %s\n", cli.URL(getPhpMyAdminURL()))
+	}
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println(cli.Bullet("Reload your shell to activate the PHP wrapper:"))

--- a/cmd/magebox/config_cmd.go
+++ b/cmd/magebox/config_cmd.go
@@ -35,7 +35,8 @@ Available keys:
   default_php  - Default PHP version for new projects (e.g., "8.2")
   tld          - Top-level domain for local dev (default: "test")
   portainer    - Enable Portainer Docker UI: "true" or "false"
-  elasticvue   - Enable Elasticvue search UI: "true" or "false"`,
+  elasticvue   - Enable Elasticvue search UI: "true" or "false"
+  phpmyadmin   - Enable phpMyAdmin database UI: "true" or "false"`,
 	Args: cobra.ExactArgs(2),
 	RunE: runConfigSet,
 }
@@ -82,6 +83,7 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  %-14s %s\n", "tld:", cli.Highlight(cfg.TLD))
 	fmt.Printf("  %-14s %s\n", "portainer:", cli.Highlight(fmt.Sprintf("%v", cfg.Portainer)))
 	fmt.Printf("  %-14s %s\n", "elasticvue:", cli.Highlight(fmt.Sprintf("%v", cfg.Elasticvue)))
+	fmt.Printf("  %-14s %s\n", "phpmyadmin:", cli.Highlight(fmt.Sprintf("%v", cfg.PhpMyAdmin)))
 	fmt.Printf("  %-14s %s\n", "auto_start:", cli.Highlight(fmt.Sprintf("%v", cfg.AutoStart)))
 
 	fmt.Println(cli.Header("Default Services"))
@@ -135,10 +137,12 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		cfg.AutoStart = (value == "true" || value == "1" || value == "yes")
 	case "elasticvue":
 		cfg.Elasticvue = (value == "true" || value == "1" || value == "yes")
+	case "phpmyadmin":
+		cfg.PhpMyAdmin = (value == "true" || value == "1" || value == "yes")
 	default:
 		cli.PrintError("Unknown configuration key: %s", key)
 		fmt.Println()
-		cli.PrintInfo("Available keys: dns_mode, default_php, tld, portainer, elasticvue, auto_start")
+		cli.PrintInfo("Available keys: dns_mode, default_php, tld, portainer, elasticvue, phpmyadmin, auto_start")
 		return nil
 	}
 

--- a/cmd/magebox/phpmyadmin.go
+++ b/cmd/magebox/phpmyadmin.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"qoliber/magebox/internal/cli"
+	"qoliber/magebox/internal/config"
+	"qoliber/magebox/internal/docker"
+)
+
+const phpmyadminDefaultPort = "8036"
+
+// getPhpMyAdminURL returns the phpMyAdmin URL, reading the actual port from the running container.
+// Falls back to the default port if the container is not running.
+func getPhpMyAdminURL() string {
+	portCmd := exec.Command("docker", "port", "magebox-phpmyadmin", "80")
+	output, err := portCmd.Output()
+	if err == nil {
+		// Output format: "0.0.0.0:8036" or "[::]:8036"
+		parts := strings.TrimSpace(string(output))
+		// Handle multiple lines (IPv4 + IPv6)
+		for _, line := range strings.Split(parts, "\n") {
+			line = strings.TrimSpace(line)
+			if idx := strings.LastIndex(line, ":"); idx != -1 {
+				port := line[idx+1:]
+				return fmt.Sprintf("http://localhost:%s", port)
+			}
+		}
+	}
+	return fmt.Sprintf("http://localhost:%s", phpmyadminDefaultPort)
+}
+
+var phpmyadminCmd = &cobra.Command{
+	Use:   "phpmyadmin",
+	Short: "phpMyAdmin database UI",
+	Long:  "Manage phpMyAdmin web UI for MySQL/MariaDB",
+}
+
+var phpmyadminEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable phpMyAdmin",
+	Long:  "Enables phpMyAdmin web UI for browsing MySQL/MariaDB databases",
+	RunE:  runPhpMyAdminEnable,
+}
+
+var phpmyadminDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable phpMyAdmin",
+	Long:  "Disables phpMyAdmin web UI",
+	RunE:  runPhpMyAdminDisable,
+}
+
+var phpmyadminStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show phpMyAdmin status",
+	Long:  "Shows phpMyAdmin status and connection information",
+	RunE:  runPhpMyAdminStatus,
+}
+
+var phpmyadminOpenCmd = &cobra.Command{
+	Use:   "open",
+	Short: "Open phpMyAdmin in browser",
+	Long:  "Opens the phpMyAdmin web UI in the default browser",
+	RunE:  runPhpMyAdminOpen,
+}
+
+func init() {
+	phpmyadminCmd.AddCommand(phpmyadminEnableCmd)
+	phpmyadminCmd.AddCommand(phpmyadminDisableCmd)
+	phpmyadminCmd.AddCommand(phpmyadminStatusCmd)
+	phpmyadminCmd.AddCommand(phpmyadminOpenCmd)
+	rootCmd.AddCommand(phpmyadminCmd)
+}
+
+func runPhpMyAdminEnable(cmd *cobra.Command, args []string) error {
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	globalCfg, err := config.LoadGlobalConfig(p.HomeDir)
+	if err != nil {
+		return fmt.Errorf("failed to load global config: %w", err)
+	}
+
+	if globalCfg.PhpMyAdmin {
+		cli.PrintInfo("phpMyAdmin is already enabled")
+		fmt.Println()
+		fmt.Printf("  Web UI: %s\n", cli.Highlight(getPhpMyAdminURL()))
+		return nil
+	}
+
+	cli.PrintTitle("Enabling phpMyAdmin")
+	fmt.Println()
+
+	globalCfg.PhpMyAdmin = true
+	if err := config.SaveGlobalConfig(p.HomeDir, globalCfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Regenerate docker-compose and start
+	fmt.Print("Starting phpMyAdmin container... ")
+	composeGen := docker.NewComposeGenerator(p)
+
+	// Discover all project configs to regenerate docker-compose
+	configs := discoverAllConfigs(p)
+	if err := composeGen.GenerateGlobalServices(configs); err != nil {
+		fmt.Println(cli.Error("failed"))
+		return fmt.Errorf("failed to generate docker-compose: %w", err)
+	}
+
+	dockerCtrl := docker.NewDockerController(composeGen.ComposeFilePath())
+	if err := dockerCtrl.StartService("phpmyadmin"); err != nil {
+		fmt.Println(cli.Error("failed"))
+		return fmt.Errorf("failed to start phpMyAdmin: %w", err)
+	}
+	fmt.Println(cli.Success("done"))
+
+	fmt.Println()
+	cli.PrintSuccess("phpMyAdmin enabled!")
+	fmt.Println()
+	fmt.Printf("  Web UI: %s\n", cli.Highlight(getPhpMyAdminURL()))
+	fmt.Println()
+	cli.PrintInfo("Use arbitrary server mode to connect to any MySQL/MariaDB instance")
+	cli.PrintInfo("Database containers are accessible by their container name (e.g. magebox-mysql-8.0)")
+
+	return nil
+}
+
+func runPhpMyAdminDisable(cmd *cobra.Command, args []string) error {
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	globalCfg, err := config.LoadGlobalConfig(p.HomeDir)
+	if err != nil {
+		return fmt.Errorf("failed to load global config: %w", err)
+	}
+
+	if !globalCfg.PhpMyAdmin {
+		cli.PrintInfo("phpMyAdmin is not enabled")
+		return nil
+	}
+
+	cli.PrintTitle("Disabling phpMyAdmin")
+	fmt.Println()
+
+	// Stop container first
+	fmt.Print("Stopping phpMyAdmin container... ")
+	composeGen := docker.NewComposeGenerator(p)
+	dockerCtrl := docker.NewDockerController(composeGen.ComposeFilePath())
+	if err := dockerCtrl.StopService("phpmyadmin"); err != nil {
+		fmt.Println(cli.Warning("not running"))
+	} else {
+		fmt.Println(cli.Success("done"))
+	}
+
+	globalCfg.PhpMyAdmin = false
+	if err := config.SaveGlobalConfig(p.HomeDir, globalCfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Regenerate docker-compose without phpMyAdmin
+	configs := discoverAllConfigs(p)
+	if err := composeGen.GenerateGlobalServices(configs); err != nil {
+		return fmt.Errorf("failed to update docker-compose: %w", err)
+	}
+
+	fmt.Println()
+	cli.PrintSuccess("phpMyAdmin disabled!")
+
+	return nil
+}
+
+func runPhpMyAdminStatus(cmd *cobra.Command, args []string) error {
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	globalCfg, err := config.LoadGlobalConfig(p.HomeDir)
+	if err != nil {
+		return fmt.Errorf("failed to load global config: %w", err)
+	}
+
+	cli.PrintTitle("phpMyAdmin Status")
+	fmt.Println()
+
+	if !globalCfg.PhpMyAdmin {
+		fmt.Println("Enabled: " + cli.Warning("no"))
+		fmt.Println()
+		cli.PrintInfo("Enable with: magebox phpmyadmin enable")
+		return nil
+	}
+
+	fmt.Println("Enabled: " + cli.Success("yes"))
+
+	// Check if container is running
+	checkCmd := exec.Command("docker", "ps", "--filter", "name=magebox-phpmyadmin", "--filter", "status=running", "-q")
+	output, err := checkCmd.Output()
+	if err == nil && len(strings.TrimSpace(string(output))) > 0 {
+		fmt.Println("Status:  " + cli.Success("running"))
+		fmt.Printf("Web UI:  %s\n", cli.Highlight(getPhpMyAdminURL()))
+	} else {
+		fmt.Println("Status:  " + cli.Warning("stopped"))
+		fmt.Println()
+		cli.PrintInfo("Start global services with: magebox global start")
+	}
+
+	return nil
+}
+
+func runPhpMyAdminOpen(cmd *cobra.Command, args []string) error {
+	// Check if container is running
+	checkCmd := exec.Command("docker", "ps", "--filter", "name=magebox-phpmyadmin", "--filter", "status=running", "-q")
+	output, err := checkCmd.Output()
+	if err != nil || len(strings.TrimSpace(string(output))) == 0 {
+		cli.PrintError("phpMyAdmin is not running")
+		fmt.Println()
+		cli.PrintInfo("Enable with: magebox phpmyadmin enable")
+		return nil
+	}
+
+	url := getPhpMyAdminURL()
+	cli.PrintInfo("Opening %s", cli.URL(url))
+
+	var openCmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		openCmd = exec.Command("open", url)
+	default:
+		openCmd = exec.Command("xdg-open", url)
+	}
+
+	return openCmd.Start()
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -27,6 +27,9 @@ type GlobalConfig struct {
 	// Elasticvue enables/disables Elasticvue web UI for OpenSearch/Elasticsearch
 	Elasticvue bool `yaml:"elasticvue,omitempty"`
 
+	// PhpMyAdmin enables/disables phpMyAdmin web UI for MySQL/MariaDB
+	PhpMyAdmin bool `yaml:"phpmyadmin,omitempty"`
+
 	// TLD is the top-level domain for local development (default: "test")
 	TLD string `yaml:"tld,omitempty"`
 

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -30,6 +30,9 @@ func TestDefaultGlobalConfig(t *testing.T) {
 	if config.Portainer {
 		t.Error("Portainer should be false by default")
 	}
+	if config.PhpMyAdmin {
+		t.Error("PhpMyAdmin should be false by default")
+	}
 	if !config.DefaultServices.Redis {
 		t.Error("Redis should be true by default")
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -165,6 +165,7 @@ type Services struct {
 	RabbitMQ      *ServiceConfig `yaml:"rabbitmq,omitempty"`
 	Mailpit       *ServiceConfig `yaml:"mailpit,omitempty"`
 	Varnish       *ServiceConfig `yaml:"varnish,omitempty"`
+	PhpMyAdmin    *ServiceConfig `yaml:"phpmyadmin,omitempty"`
 }
 
 // ServiceConfig represents a service configuration
@@ -412,6 +413,11 @@ func (s *Services) HasMailpit() bool {
 // HasVarnish returns true if Varnish service is configured
 func (s *Services) HasVarnish() bool {
 	return s.Varnish != nil && s.Varnish.Enabled
+}
+
+// HasPhpMyAdmin returns true if phpMyAdmin service is configured
+func (s *Services) HasPhpMyAdmin() bool {
+	return s.PhpMyAdmin != nil && s.PhpMyAdmin.Enabled
 }
 
 // GetDatabaseService returns the configured database service (MySQL or MariaDB)

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -278,6 +278,15 @@ func (g *ComposeGenerator) GenerateGlobalServices(configs []*config.Config) erro
 		compose.Services["elasticvue"] = g.getElasticvueService()
 	}
 
+	// Add phpMyAdmin if enabled in global config or by any project
+	if (globalCfg != nil && globalCfg.PhpMyAdmin) || requiredServices.phpmyadmin != nil {
+		port := 8036
+		if requiredServices.phpmyadmin != nil && requiredServices.phpmyadmin.Port > 0 {
+			port = requiredServices.phpmyadmin.Port
+		}
+		compose.Services["phpmyadmin"] = g.getPhpMyAdminService(requiredServices.firstDBHost(defaultMySQL, defaultMariaDB), port)
+	}
+
 	// Add Varnish if needed
 	if requiredServices.varnish != nil {
 		// Generate VCL configuration first
@@ -312,7 +321,34 @@ type requiredServices struct {
 	elasticsearch map[string]*config.ServiceConfig
 	rabbitmq      bool
 	varnish       *config.ServiceConfig
+	phpmyadmin    *config.ServiceConfig
 	// Note: Mailpit is always enabled for local dev safety, not tracked here
+}
+
+// firstDBHost returns the container name of the first available database service.
+// It prefers the default version from global config for deterministic results.
+func (rs *requiredServices) firstDBHost(defaultMySQL, defaultMariaDB string) string {
+	// Prefer the default MySQL version if available
+	if defaultMySQL != "" {
+		if _, ok := rs.mysql[defaultMySQL]; ok {
+			return fmt.Sprintf("magebox-mysql-%s", defaultMySQL)
+		}
+	}
+	// Then try any MySQL version
+	for version := range rs.mysql {
+		return fmt.Sprintf("magebox-mysql-%s", version)
+	}
+	// Prefer the default MariaDB version if available
+	if defaultMariaDB != "" {
+		if _, ok := rs.mariadb[defaultMariaDB]; ok {
+			return fmt.Sprintf("magebox-mariadb-%s", defaultMariaDB)
+		}
+	}
+	// Then try any MariaDB version
+	for version := range rs.mariadb {
+		return fmt.Sprintf("magebox-mariadb-%s", version)
+	}
+	return ""
 }
 
 // collectRequiredServices collects all required services from configs
@@ -347,6 +383,9 @@ func (g *ComposeGenerator) collectRequiredServices(configs []*config.Config) req
 			rs.rabbitmq = true
 		}
 		// Note: Mailpit is always enabled, no need to track
+		if cfg.Services.HasPhpMyAdmin() {
+			rs.phpmyadmin = cfg.Services.PhpMyAdmin
+		}
 		if cfg.Services.HasVarnish() {
 			rs.varnish = cfg.Services.Varnish
 		}
@@ -616,6 +655,26 @@ func (g *ComposeGenerator) getElasticvueService() ComposeService {
 		ContainerName: "magebox-elasticvue",
 		Image:         "cars10/elasticvue:latest",
 		Ports:         []string{"8090:8080"},
+		Networks:      []string{"magebox"},
+		Restart:       "unless-stopped",
+	}
+}
+
+// getPhpMyAdminService returns a phpMyAdmin service configuration
+func (g *ComposeGenerator) getPhpMyAdminService(dbHost string, port int) ComposeService {
+	env := map[string]string{
+		"PMA_ARBITRARY": "1",
+		"PMA_USER":      "root",
+		"PMA_PASSWORD":  DefaultDBRootPassword,
+	}
+	if dbHost != "" {
+		env["PMA_HOST"] = dbHost
+	}
+	return ComposeService{
+		ContainerName: "magebox-phpmyadmin",
+		Image:         "phpmyadmin:latest",
+		Ports:         []string{fmt.Sprintf("%d:80", port)},
+		Environment:   env,
 		Networks:      []string{"magebox"},
 		Restart:       "unless-stopped",
 	}
@@ -1017,6 +1076,17 @@ func (g *ComposeGenerator) GenerateDefaultServices(globalCfg *config.GlobalConfi
 	// Add Elasticvue if enabled
 	if globalCfg.Elasticvue {
 		compose.Services["elasticvue"] = g.getElasticvueService()
+	}
+
+	// Add phpMyAdmin if enabled
+	if globalCfg.PhpMyAdmin {
+		dbHost := ""
+		if globalCfg.DefaultServices.MySQL != "" {
+			dbHost = fmt.Sprintf("magebox-mysql-%s", globalCfg.DefaultServices.MySQL)
+		} else if globalCfg.DefaultServices.MariaDB != "" {
+			dbHost = fmt.Sprintf("magebox-mariadb-%s", globalCfg.DefaultServices.MariaDB)
+		}
+		compose.Services["phpmyadmin"] = g.getPhpMyAdminService(dbHost, 8036)
 	}
 
 	// Write compose file

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -615,6 +615,196 @@ func TestComposeGenerator_collectRequiredServices(t *testing.T) {
 	}
 }
 
+func TestComposeService_PhpMyAdmin(t *testing.T) {
+	g, _ := setupTestComposeGenerator(t)
+
+	svc := g.getPhpMyAdminService("magebox-mysql-8.0", 8036)
+
+	if svc.Image != "phpmyadmin:latest" {
+		t.Errorf("Image = %v, want phpmyadmin:latest", svc.Image)
+	}
+	if svc.ContainerName != "magebox-phpmyadmin" {
+		t.Errorf("ContainerName = %v, want magebox-phpmyadmin", svc.ContainerName)
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0] != "8036:80" {
+		t.Errorf("Ports = %v, want [8036:80]", svc.Ports)
+	}
+	if svc.Environment["PMA_ARBITRARY"] != "1" {
+		t.Error("PMA_ARBITRARY should be 1")
+	}
+	if svc.Environment["PMA_HOST"] != "magebox-mysql-8.0" {
+		t.Errorf("PMA_HOST = %v, want magebox-mysql-8.0", svc.Environment["PMA_HOST"])
+	}
+	if svc.Environment["PMA_USER"] != "root" {
+		t.Error("PMA_USER should be root")
+	}
+	if svc.Environment["PMA_PASSWORD"] != DefaultDBRootPassword {
+		t.Errorf("PMA_PASSWORD should be %s", DefaultDBRootPassword)
+	}
+	if svc.Restart != "unless-stopped" {
+		t.Error("Restart should be unless-stopped")
+	}
+}
+
+func TestComposeService_PhpMyAdmin_NoDBHost(t *testing.T) {
+	g, _ := setupTestComposeGenerator(t)
+
+	svc := g.getPhpMyAdminService("", 8036)
+
+	if _, ok := svc.Environment["PMA_HOST"]; ok {
+		t.Error("PMA_HOST should not be set when dbHost is empty")
+	}
+	if svc.Environment["PMA_ARBITRARY"] != "1" {
+		t.Error("PMA_ARBITRARY should still be 1")
+	}
+}
+
+func TestComposeService_PhpMyAdmin_CustomPort(t *testing.T) {
+	g, _ := setupTestComposeGenerator(t)
+
+	svc := g.getPhpMyAdminService("magebox-mysql-8.0", 9090)
+
+	if len(svc.Ports) != 1 || svc.Ports[0] != "9090:80" {
+		t.Errorf("Ports = %v, want [9090:80]", svc.Ports)
+	}
+}
+
+func TestRequiredServices_firstDBHost(t *testing.T) {
+	tests := []struct {
+		name           string
+		rs             requiredServices
+		defaultMySQL   string
+		defaultMariaDB string
+		want           string
+	}{
+		{
+			name: "prefers default MySQL version",
+			rs: requiredServices{
+				mysql:   map[string]*config.ServiceConfig{"5.7": {}, "8.0": {}},
+				mariadb: map[string]*config.ServiceConfig{},
+			},
+			defaultMySQL: "8.0",
+			want:         "magebox-mysql-8.0",
+		},
+		{
+			name: "falls back to any MySQL when default not present",
+			rs: requiredServices{
+				mysql:   map[string]*config.ServiceConfig{"5.7": {}},
+				mariadb: map[string]*config.ServiceConfig{},
+			},
+			defaultMySQL: "8.0",
+			want:         "magebox-mysql-5.7",
+		},
+		{
+			name: "prefers default MariaDB version",
+			rs: requiredServices{
+				mysql:   map[string]*config.ServiceConfig{},
+				mariadb: map[string]*config.ServiceConfig{"10.4": {}, "10.6": {}},
+			},
+			defaultMariaDB: "10.6",
+			want:           "magebox-mariadb-10.6",
+		},
+		{
+			name: "MySQL takes priority over MariaDB",
+			rs: requiredServices{
+				mysql:   map[string]*config.ServiceConfig{"8.0": {}},
+				mariadb: map[string]*config.ServiceConfig{"10.6": {}},
+			},
+			defaultMySQL:   "8.0",
+			defaultMariaDB: "10.6",
+			want:           "magebox-mysql-8.0",
+		},
+		{
+			name: "returns empty when no databases",
+			rs: requiredServices{
+				mysql:   map[string]*config.ServiceConfig{},
+				mariadb: map[string]*config.ServiceConfig{},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.rs.firstDBHost(tt.defaultMySQL, tt.defaultMariaDB)
+			if got != tt.want {
+				t.Errorf("firstDBHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComposeGenerator_GenerateWithPhpMyAdmin(t *testing.T) {
+	g, tmpDir := setupTestComposeGenerator(t)
+
+	// Create global config with phpMyAdmin enabled
+	configDir := filepath.Join(tmpDir, ".magebox")
+	os.MkdirAll(configDir, 0755)
+	os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("phpmyadmin: true\n"), 0644)
+
+	configs := []*config.Config{
+		{
+			Name: "project1",
+			Services: config.Services{
+				MySQL: &config.ServiceConfig{Enabled: true, Version: "8.0"},
+				Redis: &config.ServiceConfig{Enabled: true},
+			},
+		},
+	}
+
+	err := g.GenerateGlobalServices(configs)
+	if err != nil {
+		t.Fatalf("GenerateGlobalServices failed: %v", err)
+	}
+
+	content, err := os.ReadFile(g.ComposeFilePath())
+	if err != nil {
+		t.Fatalf("Failed to read compose file: %v", err)
+	}
+
+	var compose ComposeConfig
+	if err := yaml.Unmarshal(content, &compose); err != nil {
+		t.Fatalf("Failed to parse compose file: %v", err)
+	}
+
+	if _, ok := compose.Services["phpmyadmin"]; !ok {
+		t.Error("Compose should contain phpmyadmin service when enabled in global config")
+	}
+}
+
+func TestComposeGenerator_GenerateWithPhpMyAdminFromProject(t *testing.T) {
+	g, _ := setupTestComposeGenerator(t)
+
+	configs := []*config.Config{
+		{
+			Name: "project1",
+			Services: config.Services{
+				MySQL:      &config.ServiceConfig{Enabled: true, Version: "8.0"},
+				PhpMyAdmin: &config.ServiceConfig{Enabled: true},
+			},
+		},
+	}
+
+	err := g.GenerateGlobalServices(configs)
+	if err != nil {
+		t.Fatalf("GenerateGlobalServices failed: %v", err)
+	}
+
+	content, err := os.ReadFile(g.ComposeFilePath())
+	if err != nil {
+		t.Fatalf("Failed to read compose file: %v", err)
+	}
+
+	var compose ComposeConfig
+	if err := yaml.Unmarshal(content, &compose); err != nil {
+		t.Fatalf("Failed to parse compose file: %v", err)
+	}
+
+	if _, ok := compose.Services["phpmyadmin"]; !ok {
+		t.Error("Compose should contain phpmyadmin service when enabled in project config")
+	}
+}
+
 func TestComposeConfig_Networks(t *testing.T) {
 	g, _ := setupTestComposeGenerator(t)
 

--- a/vitepress/.vitepress/config.mts
+++ b/vitepress/.vitepress/config.mts
@@ -96,6 +96,7 @@ export default defineConfig({
             { text: 'Mailpit', link: '/services/mailpit' },
             { text: 'Varnish', link: '/services/varnish' },
             { text: 'Elasticvue', link: '/services/elasticvue' },
+            { text: 'phpMyAdmin', link: '/services/phpmyadmin' },
             { text: 'Blackfire', link: '/services/blackfire' },
             { text: 'Tideways', link: '/services/tideways' }
           ]
@@ -213,6 +214,7 @@ export default defineConfig({
             { text: 'Mailpit', link: '/services/mailpit' },
             { text: 'Varnish', link: '/services/varnish' },
             { text: 'Elasticvue', link: '/services/elasticvue' },
+            { text: 'phpMyAdmin', link: '/services/phpmyadmin' },
             { text: 'Blackfire', link: '/services/blackfire' },
             { text: 'Tideways', link: '/services/tideways' }
           ]

--- a/vitepress/guide/services-overview.md
+++ b/vitepress/guide/services-overview.md
@@ -43,6 +43,7 @@ services:
 | Mailpit | latest | 1025, 8025 |
 | Varnish | latest | 6081 |
 | Elasticvue | latest | 8090 |
+| phpMyAdmin | latest | 8036 |
 
 ## Service Management
 

--- a/vitepress/services/phpmyadmin.md
+++ b/vitepress/services/phpmyadmin.md
@@ -1,0 +1,142 @@
+# phpMyAdmin
+
+MageBox supports [phpMyAdmin](https://www.phpmyadmin.net/), a web-based administration tool for MySQL and MariaDB databases.
+
+## Overview
+
+phpMyAdmin provides a visual interface for:
+
+- **Browsing databases**, tables, and records
+- **Running SQL queries** directly in the browser
+- **Importing and exporting** data (SQL, CSV, etc.)
+- **Managing users**, permissions, and privileges
+- **Viewing and editing** table structure and data
+
+## Enabling phpMyAdmin
+
+### Via Command
+
+```bash
+magebox phpmyadmin enable
+```
+
+### Via Global Config
+
+```bash
+magebox config set phpmyadmin true
+```
+
+Then start services:
+
+```bash
+magebox global start
+```
+
+### Via Project Config
+
+Add to your `.magebox.yaml`:
+
+```yaml
+services:
+  mysql: "8.0"
+  phpmyadmin: true
+```
+
+To use a custom port:
+
+```yaml
+services:
+  mysql: "8.0"
+  phpmyadmin:
+    port: 9090
+```
+
+## Connection Details
+
+| Setting | Value |
+|---------|-------|
+| Web UI | `http://localhost:8036` |
+| Username | `root` |
+| Password | `magebox` |
+
+## Getting Started
+
+1. Enable phpMyAdmin:
+   ```bash
+   magebox phpmyadmin enable
+   ```
+
+2. Open **http://localhost:8036** in your browser
+
+3. phpMyAdmin auto-connects to your default MySQL/MariaDB instance with root credentials
+
+## Connecting to Multiple Databases
+
+phpMyAdmin runs with **arbitrary server mode** enabled, which means you can connect to any MySQL or MariaDB instance from the login screen. Use the container name as the server host:
+
+| Database | Server Host |
+|----------|-------------|
+| MySQL 5.7 | `magebox-mysql-5.7` |
+| MySQL 8.0 | `magebox-mysql-8.0` |
+| MySQL 8.4 | `magebox-mysql-8.4` |
+| MariaDB 10.4 | `magebox-mariadb-10.4` |
+| MariaDB 10.6 | `magebox-mariadb-10.6` |
+| MariaDB 11.4 | `magebox-mariadb-11.4` |
+
+## MageBox Commands
+
+### Open in Browser
+
+```bash
+magebox phpmyadmin open
+```
+
+Opens the phpMyAdmin web UI in your default browser.
+
+### Check Status
+
+```bash
+magebox phpmyadmin status
+```
+
+Shows whether phpMyAdmin is enabled and running.
+
+### Disable
+
+```bash
+magebox phpmyadmin disable
+```
+
+Stops the container and removes it from docker-compose.
+
+## Docker Container
+
+phpMyAdmin runs as a Docker container (`magebox-phpmyadmin`) with:
+
+- **Image**: `phpmyadmin:latest`
+- **Port**: 8036 (Web UI)
+- **Network**: magebox
+
+## Troubleshooting
+
+### Cannot Connect to Database
+
+Ensure your database service is running:
+
+```bash
+magebox global status
+```
+
+If not, start services:
+
+```bash
+magebox global start
+```
+
+### Port 8036 Already in Use
+
+If another service is using port 8036, stop it before enabling phpMyAdmin:
+
+```bash
+lsof -i :8036
+```


### PR DESCRIPTION
I was missing this when I was debugging, so I added it :)  Not sure if it complies to project structure but I tried to stick with it.

Add phpMyAdmin web UI for MySQL/MariaDB with global toggle (magebox phpmyadmin enable/disable) and per-project config (phpmyadmin: true in .magebox.yaml). Features configurable port, arbitrary server mode for multiple DB versions, auto-login with root credentials, and CLI commands for enable/disable/status/open.