### PR TITLE
Add purge command to clear generated files and caches

### DIFF
--- a/cmd/magebox/purge.go
+++ b/cmd/magebox/purge.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"qoliber/magebox/internal/cli"
+	"qoliber/magebox/internal/config"
+)
+
+var purgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Purge all generated files and caches",
+	Long: `Removes all generated files, preprocessed views, and caches.
+
+Clears:
+  - generated/metadata/*
+  - generated/code/*
+  - pub/static/*
+  - var/cache/*
+  - var/composer_home/*
+  - var/page_cache/*
+  - var/view_preprocessed/*
+  - Redis/Valkey (if configured)
+  - Varnish (if configured)
+
+Examples:
+  magebox purge`,
+	RunE: runPurge,
+}
+
+func init() {
+	rootCmd.AddCommand(purgeCmd)
+}
+
+// purgeDirs are the Magento directories to clean, relative to project root
+var purgeDirs = []string{
+	"generated/metadata/*",
+	"generated/code/*",
+	"pub/static/*",
+	"var/cache/*",
+	"var/composer_home/*",
+	"var/page_cache/*",
+	"var/view_preprocessed/*",
+}
+
+func runPurge(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	cli.PrintTitle("Purge")
+	fmt.Println()
+
+	// Remove generated files and caches in parallel
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, pattern := range purgeDirs {
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			purgeGlob(cwd, p, &mu)
+		}(pattern)
+	}
+	wg.Wait()
+
+	// Flush Redis/Valkey
+	flushCache(cfg)
+
+	// Flush Varnish
+	flushVarnish(cfg)
+
+	fmt.Println()
+	cli.PrintSuccess("All caches purged!")
+	return nil
+}
+
+// purgeGlob removes all files matching a glob pattern relative to the project root
+func purgeGlob(cwd, pattern string, mu *sync.Mutex) {
+	fullPattern := filepath.Join(cwd, pattern)
+	matches, _ := filepath.Glob(fullPattern)
+
+	for _, match := range matches {
+		os.RemoveAll(match)
+	}
+
+	mu.Lock()
+	fmt.Printf("  %s %s\n", cli.Success(cli.SymbolCheck), pattern)
+	mu.Unlock()
+}
+
+// flushCache flushes Redis or Valkey if configured
+func flushCache(cfg *config.Config) {
+	if cfg.Services.HasRedis() {
+		flushRedis("magebox-redis")
+	} else if cfg.Services.HasValkey() {
+		flushRedis("magebox-valkey")
+	}
+}
+
+// flushRedis sends FLUSHALL to a Redis-compatible container
+func flushRedis(containerName string) {
+	cmd := exec.Command("docker", "exec", containerName, "redis-cli", "flushall")
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("  %s Redis flush (not running)\n", cli.Warning(cli.SymbolWarning))
+		return
+	}
+	fmt.Printf("  %s Redis caches flushed\n", cli.Success(cli.SymbolCheck))
+}
+
+// flushVarnish bans all URLs if Varnish is configured
+func flushVarnish(cfg *config.Config) {
+	if !cfg.Services.HasVarnish() {
+		return
+	}
+
+	cmd := exec.Command("docker", "exec", "magebox-varnish", "varnishadm", "ban", "req.url", "~", ".")
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("  %s Varnish flush (not running)\n", cli.Warning(cli.SymbolWarning))
+		return
+	}
+	fmt.Printf("  %s Varnish caches flushed\n", cli.Success(cli.SymbolCheck))
+}

--- a/cmd/magebox/purge_test.go
+++ b/cmd/magebox/purge_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"qoliber/magebox/internal/config"
+)
+
+func TestPurgeGlob(t *testing.T) {
+	// Create a temp project directory with Magento-like structure
+	projectDir := t.TempDir()
+
+	// Create directories and files to purge
+	dirs := []string{
+		"generated/metadata",
+		"generated/code/Vendor/Module",
+		"pub/static/frontend/Vendor/theme",
+		"var/cache/mage-tags",
+		"var/composer_home/cache",
+		"var/page_cache/html",
+		"var/view_preprocessed/css",
+	}
+	for _, d := range dirs {
+		fullPath := filepath.Join(projectDir, d)
+		if err := os.MkdirAll(fullPath, 0755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", d, err)
+		}
+		// Create a file inside each dir
+		if err := os.WriteFile(filepath.Join(fullPath, "test.txt"), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create file in %s: %v", d, err)
+		}
+	}
+
+	// Verify files exist before purge
+	for _, d := range dirs {
+		entries, _ := os.ReadDir(filepath.Join(projectDir, d))
+		if len(entries) == 0 {
+			t.Fatalf("expected files in %s before purge", d)
+		}
+	}
+
+	// Run purgeGlob on each pattern
+	var mu sync.Mutex
+	for _, pattern := range purgeDirs {
+		purgeGlob(projectDir, pattern, &mu)
+	}
+
+	// Verify contents are removed but parent dirs still exist
+	checks := []struct {
+		dir       string
+		wantEmpty bool
+	}{
+		{"generated/metadata", true},
+		{"generated/code", true},
+		{"pub/static", true},
+		{"var/cache", true},
+		{"var/composer_home", true},
+		{"var/page_cache", true},
+		{"var/view_preprocessed", true},
+	}
+
+	for _, c := range checks {
+		fullPath := filepath.Join(projectDir, c.dir)
+		entries, err := os.ReadDir(fullPath)
+		if err != nil {
+			// Parent dir may have been removed by glob, that's ok
+			continue
+		}
+		if c.wantEmpty && len(entries) > 0 {
+			t.Errorf("%s should be empty after purge, has %d entries", c.dir, len(entries))
+		}
+	}
+}
+
+func TestPurgeGlob_EmptyDir(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Create empty directories (nothing to purge)
+	os.MkdirAll(filepath.Join(projectDir, "var/cache"), 0755)
+
+	// Should not panic or error on empty dirs
+	var mu sync.Mutex
+	purgeGlob(projectDir, "var/cache/*", &mu)
+}
+
+func TestPurgeGlob_NonExistent(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Should not panic on non-existent directories
+	var mu sync.Mutex
+	purgeGlob(projectDir, "nonexistent/path/*", &mu)
+}
+
+func TestPurgeDirs(t *testing.T) {
+	// Verify all expected directories are in the purge list
+	expected := map[string]bool{
+		"generated/metadata/*":    false,
+		"generated/code/*":        false,
+		"pub/static/*":            false,
+		"var/cache/*":             false,
+		"var/composer_home/*":     false,
+		"var/page_cache/*":        false,
+		"var/view_preprocessed/*": false,
+	}
+
+	for _, d := range purgeDirs {
+		if _, ok := expected[d]; ok {
+			expected[d] = true
+		} else {
+			t.Errorf("unexpected purge dir: %s", d)
+		}
+	}
+
+	for d, found := range expected {
+		if !found {
+			t.Errorf("missing purge dir: %s", d)
+		}
+	}
+}
+
+func TestFlushCache_NoService(t *testing.T) {
+	// Should not panic when no cache service configured
+	cfg := &config.Config{}
+	flushCache(cfg)
+}
+
+func TestFlushVarnish_NotConfigured(t *testing.T) {
+	// Should not panic when Varnish is not configured
+	cfg := &config.Config{}
+	flushVarnish(cfg)
+}

--- a/vitepress/reference/commands.md
+++ b/vitepress/reference/commands.md
@@ -678,6 +678,26 @@ magebox db snapshot delete mybackup
 **Arguments:**
 - `name` - Snapshot name to delete (required)
 
+## Purge Command
+
+### `magebox purge`
+
+Remove all generated files, caches, and preprocessed views.
+
+```bash
+magebox purge
+```
+
+Clears:
+- `generated/metadata/*` and `generated/code/*`
+- `pub/static/*`
+- `var/cache/*`, `var/page_cache/*`, `var/view_preprocessed/*`
+- `var/composer_home/*`
+- Redis/Valkey (if configured)
+- Varnish (if configured)
+
+---
+
 ## Redis Commands
 
 These commands work with both Redis and Valkey.


### PR DESCRIPTION
Add command `magebox purge` to remove all generated code, preprocessed views, static content, and caches in parallel. Flushes Redis/Valkey and Varnish when configured.