### PR TITLE
Add IPv6 support to macOS port forwarding and nginx

### DIFF
--- a/internal/nginx/vhost.go
+++ b/internal/nginx/vhost.go
@@ -140,7 +140,6 @@ func (g *VhostGenerator) Generate(cfg *config.Config, projectPath string) error 
 	if g.platform.Type == platform.Darwin {
 		httpPort = 8080
 		httpsPort = 8443
-		enableIPv6 = false
 	}
 
 	for _, domain := range cfg.Domains {
@@ -326,7 +325,7 @@ func (g *VhostGenerator) GenerateProxyVhost(cfg ProxyConfig) error {
 	if g.platform.Type == platform.Darwin {
 		cfg.HTTPPort = 8080
 		cfg.HTTPSPort = 8443
-		cfg.EnableIPv6 = false
+		cfg.EnableIPv6 = true
 	}
 
 	// Generate SSL certificate if enabled

--- a/internal/portforward/pf.go
+++ b/internal/portforward/pf.go
@@ -35,7 +35,7 @@ func NewManager() *Manager {
 
 // launchDaemonVersion is incremented when the plist content changes
 // This ensures existing users get updates when they run bootstrap
-const launchDaemonVersion = "3"
+const launchDaemonVersion = "4"
 
 // Setup installs the port forwarding rules and LaunchDaemon
 func (m *Manager) Setup() error {
@@ -49,10 +49,17 @@ func (m *Manager) Setup() error {
 	if m.IsInstalled() {
 		verbose.Debug("Port forwarding plist exists, checking version...")
 
+		// Always ensure pf rules and config are up to date
+		if err := m.createPfRules(); err != nil {
+			return fmt.Errorf("failed to update pf rules: %w", err)
+		}
+		if err := m.reloadPfRules(); err != nil {
+			return fmt.Errorf("failed to reload pf rules: %w", err)
+		}
+
 		// Check if we need to upgrade the LaunchDaemon
 		if m.needsUpgrade() {
 			verbose.Debug("LaunchDaemon needs upgrade, reinstalling...")
-			// Unload old daemon, install new one
 			_ = m.unloadLaunchDaemon()
 			if err := m.createLaunchDaemon(); err != nil {
 				return fmt.Errorf("failed to upgrade launch daemon: %w", err)
@@ -63,13 +70,8 @@ func (m *Manager) Setup() error {
 			verbose.Debug("LaunchDaemon upgraded to version %s", launchDaemonVersion)
 		}
 
-		// Verify rules are active
-		if m.areRulesActive() {
-			verbose.Debug("Port forwarding already configured and active")
-			return nil
-		}
-		verbose.Debug("Rules not active, reloading...")
-		return m.reloadPfRules()
+		verbose.Debug("Port forwarding configured and active")
+		return nil
 	}
 
 	verbose.Debug("Installing port forwarding (requires sudo)...")
@@ -99,7 +101,7 @@ func (m *Manager) Setup() error {
 		return fmt.Errorf("failed to reload pf rules: %w", err)
 	}
 
-	verbose.Debug("Port forwarding configured: 80 → 8080, 443 → 8443")
+	verbose.Debug("Port forwarding configured: 80 → 8080, 443 → 8443 (IPv4 + IPv6)")
 	return nil
 }
 
@@ -165,9 +167,11 @@ func (m *Manager) Remove() error {
 // createPfRules creates the pf (packet filter) rules file
 func (m *Manager) createPfRules() error {
 	rules := `# MageBox port forwarding rules
-# Forward privileged ports to unprivileged ports
+# Forward privileged ports to unprivileged ports (IPv4 and IPv6)
 rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
 rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+rdr pass on lo0 inet6 proto tcp from any to ::1 port 80 -> ::1 port 8080
+rdr pass on lo0 inet6 proto tcp from any to ::1 port 443 -> ::1 port 8443
 `
 
 	// Ensure directory exists


### PR DESCRIPTION
## Summary

Fixes connection refused errors on macOS when accessing `.test` domains via HTTPS (or HTTP). This is the macOS counterpart to #20, which solved the same root cause on Linux.

## Problem

macOS resolves `.test` domains (via `/etc/resolver/test`) to both `::1` (IPv6) and `127.0.0.1` (IPv4). Browsers and curl prefer IPv6 and connect to `[::1]:443` first. However:

1. The pf redirect rules only handled IPv4 (`inet`), so `[::1]:443` was never forwarded to nginx on port 8443
2. Nginx on macOS had `EnableIPv6 = false`, so it wasn't listening on `[::]:8080` / `[::]:8443`

The result: immediate connection refused, with no fallback to IPv4.

#20 addressed this on Linux by adding `[::]:port` listen directives to nginx, noting "macOS is unaffected as it uses port forwarding." Turns out macOS is affected too — just at the pf layer rather than the nginx layer.

## Changes

- **`internal/portforward/pf.go`** — Add `inet6` redirect rules for loopback, bump LaunchDaemon version to `4`
- **`internal/nginx/vhost.go`** — Enable `EnableIPv6 = true` on macOS so nginx listens on `[::]:8080` and `[::]:8443`

## Design decisions

**Why always rewrite pf rules on bootstrap?**

The original `Setup()` only wrote pf rules on fresh install or when the LaunchDaemon version changed. This created a problem: the pf rules file and the LaunchDaemon version could get out of sync (e.g., if the daemon was upgraded but the rules write failed, or if a user ran bootstrap multiple times). Since the rules file is small and writing it is idempotent, we now always write and reload it during bootstrap. The LaunchDaemon still uses version-gated upgrades since it requires unload/load cycles.

**Why enable IPv6 in nginx on macOS?**

Even with IPv6 pf rules redirecting `[::1]:443` → `[::1]:8443`, nginx needs to accept connections on the IPv6 address. Enabling `EnableIPv6` adds `listen [::]:8080` and `listen [::]:8443` directives to the vhost templates, which is what #20 already did for Linux.

## Test plan

- [ ] Fresh install: remove pf config (`sudo rm /Library/LaunchDaemons/com.magebox.portforward.plist /etc/pf.anchors/com.magebox`), run `magebox bootstrap`, verify `.test` domains work
- [ ] Upgrade from v3: set plist to `MageBox-Version-3`, run `magebox bootstrap`, verify pf rules contain `inet6` lines and `.test` domains work
- [ ] Verify `curl -v https://<project>.test` connects via `[::1]:443`
- [ ] Verify IPv4 still works: `curl --resolve "<project>.test:443:127.0.0.1" https://<project>.test`
- [ ] Linux: no behavioral change (already uses `EnableIPv6 = true` and doesn't use pf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)