### PR TITLE
Add db query command

### DIFF
--- a/cmd/magebox/db.go
+++ b/cmd/magebox/db.go
@@ -76,6 +76,14 @@ var dbTopCmd = &cobra.Command{
 	RunE:  runDbTop,
 }
 
+var dbQueryCmd = &cobra.Command{
+	Use:   "query [sql]",
+	Short: "Execute a SQL query",
+	Long:  "Executes a SQL query against the project database and prints the result",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDbQuery,
+}
+
 var dbSnapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Database snapshots",
@@ -121,6 +129,7 @@ func init() {
 	dbCmd.AddCommand(dbDropCmd)
 	dbCmd.AddCommand(dbResetCmd)
 	dbCmd.AddCommand(dbTopCmd)
+	dbCmd.AddCommand(dbQueryCmd)
 	dbCmd.AddCommand(dbSnapshotCmd)
 
 	// Snapshot subcommands
@@ -575,6 +584,38 @@ func runDbTop(cmd *cobra.Command, args []string) error {
 	topCmd.Stderr = os.Stderr
 
 	return topCmd.Run()
+}
+
+func runDbQuery(cmd *cobra.Command, args []string) error {
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	cfg, ok := loadProjectConfig(cwd)
+	if !ok {
+		return nil
+	}
+
+	db, err := getDbInfo(cfg)
+	if err != nil {
+		cli.PrintError("%v", err)
+		return nil
+	}
+
+	dbName := cfg.DatabaseName()
+	query := args[0]
+
+	queryCmd := exec.Command("docker", "exec", db.ContainerName,
+		"mysql", "-uroot", "-p"+docker.DefaultDBRootPassword, dbName, "-e", query)
+	queryCmd.Stdout = os.Stdout
+	queryCmd.Stderr = os.Stderr
+
+	if err := queryCmd.Run(); err != nil {
+		return fmt.Errorf("query failed: %w", err)
+	}
+
+	return nil
 }
 
 // getSnapshotDir returns the directory for storing snapshots


### PR DESCRIPTION
## Summary
- Adds `magebox db query "SQL"` command to execute SQL queries directly from the CLI without opening an interactive shell
- Usage: `magebox db query "SELECT * FROM core_config_data LIMIT 5"`

## Test plan
- [ ] Run `magebox db query "SHOW TABLES"` and verify output
- [ ] Run `magebox db query "SELECT 1"` and verify result
- [ ] Run without args and verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)