### PR TITLE
Add sandbox command for running AI agents in bubblewrap

### DIFF
--- a/cmd/magebox/sandbox.go
+++ b/cmd/magebox/sandbox.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"qoliber/magebox/internal/cli"
+	"qoliber/magebox/internal/config"
+	"qoliber/magebox/internal/platform"
+	"qoliber/magebox/internal/sandbox"
+)
+
+var sandboxDryRun bool
+
+var sandboxCmd = &cobra.Command{
+	Use:   "sandbox [tool] [-- tool-args...]",
+	Short: "Run an AI coding agent in a sandboxed environment",
+	Long: `Launches an AI coding agent inside a bubblewrap (bwrap) sandbox.
+
+The sandbox restricts filesystem access to:
+  - Read-only: system binaries, libraries, and certificates
+  - Read-write: current project directory and tool config dirs
+
+This prevents AI agents from accessing or modifying files outside the project.
+
+Requires bubblewrap to be installed (Linux only).
+
+Examples:
+  magebox sandbox                             # Launch claude (default) in sandbox
+  magebox sandbox claude                      # Same as above, explicit
+  magebox sandbox codex                       # Launch codex in sandbox
+  magebox sandbox claude --resume             # Pass extra args to claude
+  magebox sandbox --dry-run                   # Print the bwrap command without running it`,
+	RunE:               runSandbox,
+	Args:               cobra.ArbitraryArgs,
+	Aliases:            []string{"sb"},
+	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+}
+
+func init() {
+	sandboxCmd.Flags().BoolVar(&sandboxDryRun, "dry-run", false, "Print the bwrap command without executing it")
+	rootCmd.AddCommand(sandboxCmd)
+}
+
+func runSandbox(cmd *cobra.Command, args []string) error {
+	// Platform check - Linux only
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+	if p.Type != platform.Linux {
+		return fmt.Errorf("the sandbox command requires Linux (bubblewrap is a Linux-specific technology)")
+	}
+
+	cwd, err := getCwd()
+	if err != nil {
+		return err
+	}
+
+	mgr := sandbox.NewManager(p.HomeDir, cwd)
+
+	// Check bwrap is installed and working (skip for dry-run)
+	if !sandboxDryRun {
+		if err := mgr.CheckAvailable(); err != nil {
+			return err
+		}
+	}
+
+	// Load config (global + project, both optional)
+	homeDir, _ := os.UserHomeDir()
+	globalCfg, _ := config.LoadGlobalConfig(homeDir)
+	projectCfg, _ := config.LoadFromPath(cwd)
+
+	var globalSandbox, projectSandbox *config.SandboxConfig
+	if globalCfg != nil {
+		globalSandbox = globalCfg.Sandbox
+	}
+	if projectCfg != nil {
+		projectSandbox = projectCfg.Sandbox
+	}
+	sandboxCfg := sandbox.MergeSandboxConfigs(globalSandbox, projectSandbox)
+
+	// Determine tool name and args
+	toolName := "claude"
+	if sandboxCfg.DefaultTool != "" {
+		toolName = sandboxCfg.DefaultTool
+	}
+	var toolArgs []string
+
+	if len(args) > 0 {
+		if strings.HasPrefix(args[0], "-") {
+			// First arg is a flag — pass all args to the default tool
+			toolArgs = args
+		} else {
+			toolName = args[0]
+			toolArgs = args[1:]
+		}
+	}
+
+	// Resolve tool profile
+	profile := sandbox.ResolveProfile(toolName, sandboxCfg)
+
+	opts := sandbox.Options{
+		Profile:      profile,
+		ExtraROBinds: sandboxCfg.ExtraROBinds,
+		ExtraBinds:   sandboxCfg.ExtraBinds,
+	}
+
+	if sandboxDryRun {
+		cli.PrintInfo("Dry run — bwrap command:")
+		fmt.Println()
+		fmt.Println(mgr.FormatCommand(toolName, toolArgs, opts))
+		return nil
+	}
+
+	cli.PrintInfo("Launching %s in bubblewrap sandbox...", cli.Highlight(toolName))
+	return mgr.Run(toolName, toolArgs, opts)
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -50,6 +50,9 @@ type GlobalConfig struct {
 
 	// Environments stores remote server configurations
 	Environments []remote.Environment `yaml:"environments,omitempty"`
+
+	// Sandbox configures the bubblewrap sandbox for AI coding agents
+	Sandbox *SandboxConfig `yaml:"sandbox,omitempty"`
 }
 
 // ProfilingConfig contains credentials for profiling tools

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -26,6 +26,7 @@ type Config struct {
 	Commands    map[string]Command `yaml:"commands,omitempty"`
 	Testing     *TestingConfig     `yaml:"testing,omitempty"`
 	ComposeFile string             `yaml:"compose_file,omitempty"` // Path to project-specific docker-compose.yml
+	Sandbox     *SandboxConfig     `yaml:"sandbox,omitempty"`
 }
 
 // GetType returns the project type, defaulting to "magento"
@@ -106,6 +107,30 @@ type PHPMDTestConfig struct {
 	Ruleset string   `yaml:"ruleset,omitempty"`
 	Config  string   `yaml:"config,omitempty"`
 	Paths   []string `yaml:"paths,omitempty"`
+}
+
+// SandboxConfig configures the bubblewrap sandbox for AI coding agents
+type SandboxConfig struct {
+	// DefaultTool is the default command to run (default: "claude")
+	DefaultTool string `yaml:"default_tool,omitempty"`
+	// ExtraROBinds are additional read-only bind mounts
+	ExtraROBinds []string `yaml:"extra_ro_binds,omitempty"`
+	// ExtraBinds are additional read-write bind mounts
+	ExtraBinds []string `yaml:"extra_binds,omitempty"`
+	// ToolProfiles overrides for known tool configs
+	ToolProfiles map[string]SandboxToolProfile `yaml:"tool_profiles,omitempty"`
+}
+
+// SandboxToolProfile defines sandbox config for a specific AI tool
+type SandboxToolProfile struct {
+	// Command is the binary name or path to execute
+	Command string `yaml:"command,omitempty"`
+	// Args are default arguments for this tool
+	Args []string `yaml:"args,omitempty"`
+	// ConfigDirs are directories to bind read-write (e.g., ~/.claude)
+	ConfigDirs []string `yaml:"config_dirs,omitempty"`
+	// ConfigFiles are individual files to bind read-write
+	ConfigFiles []string `yaml:"config_files,omitempty"`
 }
 
 // Command represents a custom command that can be run via "magebox run <name>"

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,322 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"qoliber/magebox/internal/config"
+	"qoliber/magebox/internal/verbose"
+)
+
+const bwrapBinary = "bwrap"
+
+// systemROBinds are system paths mounted read-only in the sandbox.
+// Paths that don't exist on the host are silently skipped.
+var systemROBinds = []string{
+	"/bin",
+	"/lib",
+	"/lib32",
+	"/lib64",
+	"/usr/bin",
+	"/usr/lib",
+	"/usr/local/bin",
+	"/usr/local/lib",
+	"/etc/alternatives",
+	"/etc/resolv.conf",
+	"/etc/ssl/certs",
+	"/etc/ld.so.cache",
+	"/etc/ld.so.conf",
+	"/etc/ld.so.conf.d",
+	"/etc/localtime",
+	"/etc/profile.d",
+	"/etc/bash_completion.d",
+	"/etc/nsswitch.conf",
+	"/etc/hosts",
+	"/etc/ssl/openssl.cnf",
+	"/usr/share/terminfo",
+	"/usr/share/ca-certificates",
+	"/usr/share/zoneinfo",
+}
+
+// userROBinds are user home paths mounted read-only (relative to ~).
+var userROBinds = []string{
+	".bashrc",
+	".zshrc",
+	".profile",
+	".gitconfig",
+	".local",
+}
+
+// Manager handles sandbox execution
+type Manager struct {
+	homeDir    string
+	projectDir string
+}
+
+// NewManager creates a new sandbox manager
+func NewManager(homeDir, projectDir string) *Manager {
+	return &Manager{homeDir: homeDir, projectDir: projectDir}
+}
+
+// CheckAvailable verifies bwrap is installed and that user namespaces are permitted
+func (m *Manager) CheckAvailable() error {
+	bwrapPath, err := exec.LookPath(bwrapBinary)
+	if err != nil {
+		return fmt.Errorf("bubblewrap (bwrap) is not installed\n\n" +
+			"Install it with:\n" +
+			"  Debian/Ubuntu:  sudo apt install bubblewrap\n" +
+			"  Fedora/RHEL:    sudo dnf install bubblewrap\n" +
+			"  Arch:           sudo pacman -S bubblewrap")
+	}
+
+	// Quick smoke test: try a minimal bwrap invocation to catch permission issues early
+	test := exec.Command(bwrapPath, "--ro-bind", "/", "/", "true")
+	if output, err := test.CombinedOutput(); err != nil {
+		out := strings.TrimSpace(string(output))
+		if strings.Contains(out, "Permission denied") && isAppArmorRestrictingUserns() {
+			return fmt.Errorf("bubblewrap cannot create user namespaces (blocked by AppArmor)\n\n"+
+				"Fix by creating an AppArmor profile for bwrap:\n\n"+
+				"  sudo tee /etc/apparmor.d/bwrap <<'EOF'\n"+
+				"  abi <abi/4.0>,\n"+
+				"  include <tunables/global>\n\n"+
+				"  profile bwrap %s flags=(unconfined) {\n"+
+				"    userns,\n"+
+				"    include if exists <local/bwrap>\n"+
+				"  }\n"+
+				"  EOF\n\n"+
+				"  sudo apparmor_parser -r /etc/apparmor.d/bwrap", bwrapPath)
+		}
+		return fmt.Errorf("bubblewrap test failed: %s\n%s", err, out)
+	}
+
+	return nil
+}
+
+// isAppArmorRestrictingUserns checks if AppArmor is blocking unprivileged user namespaces
+func isAppArmorRestrictingUserns() bool {
+	data, err := os.ReadFile("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "1"
+}
+
+// Options holds the resolved options for a sandbox run
+type Options struct {
+	Profile      ToolProfile
+	ExtraROBinds []string
+	ExtraBinds   []string
+}
+
+// BuildArgs constructs the full bwrap argument list.
+// The returned slice does NOT include the bwrap binary itself.
+func (m *Manager) BuildArgs(tool string, toolArgs []string, opts Options) []string {
+	var args []string
+
+	// Filesystem setup
+	args = append(args, "--tmpfs", "/tmp")
+	args = append(args, "--dev", "/dev")
+	args = append(args, "--proc", "/proc")
+
+	// Hostname isolation
+	args = append(args, "--hostname", "magebox-sandbox", "--unshare-uts")
+
+	// System read-only binds
+	for _, p := range systemROBinds {
+		if pathExists(p) {
+			args = append(args, "--ro-bind", p, p)
+		}
+	}
+
+	// User read-only binds
+	for _, rel := range userROBinds {
+		p := filepath.Join(m.homeDir, rel)
+		if pathExists(p) {
+			args = append(args, "--ro-bind", p, p)
+		}
+	}
+
+	// Tool config dirs (read-write)
+	for _, dir := range opts.Profile.ConfigDirs {
+		expanded := expandHome(dir, m.homeDir)
+		if pathExists(expanded) {
+			args = append(args, "--bind", expanded, expanded)
+		}
+	}
+
+	// Tool config files (read-write)
+	for _, file := range opts.Profile.ConfigFiles {
+		expanded := expandHome(file, m.homeDir)
+		if pathExists(expanded) {
+			args = append(args, "--bind", expanded, expanded)
+		}
+	}
+
+	// Extra read-only binds from config
+	for _, bind := range opts.ExtraROBinds {
+		expanded := expandHome(bind, m.homeDir)
+		if pathExists(expanded) {
+			args = append(args, "--ro-bind", expanded, expanded)
+		}
+	}
+
+	// Extra read-write binds from config
+	for _, bind := range opts.ExtraBinds {
+		expanded := expandHome(bind, m.homeDir)
+		if pathExists(expanded) {
+			args = append(args, "--bind", expanded, expanded)
+		}
+	}
+
+	// Project directory (read-write)
+	args = append(args, "--bind", m.projectDir, m.projectDir)
+
+	// Separator between bwrap flags and the tool command
+	args = append(args, "--")
+
+	// Tool command and arguments
+	toolBin := opts.Profile.Command
+	if toolBin == "" {
+		toolBin = tool
+	}
+	args = append(args, toolBin)
+
+	// Default tool args (unless overridden by explicit toolArgs)
+	if len(toolArgs) == 0 {
+		args = append(args, opts.Profile.Args...)
+	} else {
+		args = append(args, toolArgs...)
+	}
+
+	return args
+}
+
+// FormatCommand returns the full bwrap command as a string for dry-run display.
+// Groups flag arguments together on the same line for readability.
+func (m *Manager) FormatCommand(tool string, toolArgs []string, opts Options) string {
+	args := m.BuildArgs(tool, toolArgs, opts)
+
+	var lines []string
+	lines = append(lines, bwrapBinary)
+
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+
+		// "--" separator marks the end of bwrap flags
+		if arg == "--" {
+			i++
+			// Everything after "--" is the tool command + args
+			var cmdParts []string
+			for i < len(args) {
+				val := args[i]
+				if strings.Contains(val, " ") {
+					val = fmt.Sprintf("%q", val)
+				}
+				cmdParts = append(cmdParts, val)
+				i++
+			}
+			lines = append(lines, "    "+strings.Join(cmdParts, " "))
+			break
+		}
+
+		if strings.HasPrefix(arg, "--") {
+			// Collect the flag and its arguments on one line
+			line := "    " + arg
+			i++
+			for i < len(args) && !strings.HasPrefix(args[i], "--") {
+				val := args[i]
+				if strings.Contains(val, " ") {
+					val = fmt.Sprintf("%q", val)
+				}
+				line += " " + val
+				i++
+			}
+			lines = append(lines, line)
+		} else {
+			i++
+		}
+	}
+
+	return strings.Join(lines, " \\\n")
+}
+
+// Run executes the tool inside the bubblewrap sandbox
+func (m *Manager) Run(tool string, toolArgs []string, opts Options) error {
+	bwrapPath, err := exec.LookPath(bwrapBinary)
+	if err != nil {
+		return fmt.Errorf("bwrap not found: %w", err)
+	}
+
+	args := m.BuildArgs(tool, toolArgs, opts)
+	verbose.Debug("Running: %s %s", bwrapPath, strings.Join(args, " "))
+
+	cmd := exec.Command(bwrapPath, args...)
+	cmd.Dir = m.projectDir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	return cmd.Run()
+}
+
+// MergeSandboxConfigs merges global and project sandbox configs.
+// Project config values take precedence.
+func MergeSandboxConfigs(global, project *config.SandboxConfig) *config.SandboxConfig {
+	if global == nil && project == nil {
+		return &config.SandboxConfig{}
+	}
+	if global == nil {
+		return project
+	}
+	if project == nil {
+		return global
+	}
+
+	merged := &config.SandboxConfig{
+		DefaultTool:  global.DefaultTool,
+		ExtraROBinds: append([]string{}, global.ExtraROBinds...),
+		ExtraBinds:   append([]string{}, global.ExtraBinds...),
+		ToolProfiles: make(map[string]config.SandboxToolProfile),
+	}
+
+	// Project default tool overrides global
+	if project.DefaultTool != "" {
+		merged.DefaultTool = project.DefaultTool
+	}
+
+	// Accumulate extra binds from both
+	merged.ExtraROBinds = append(merged.ExtraROBinds, project.ExtraROBinds...)
+	merged.ExtraBinds = append(merged.ExtraBinds, project.ExtraBinds...)
+
+	// Merge tool profiles
+	for k, v := range global.ToolProfiles {
+		merged.ToolProfiles[k] = v
+	}
+	for k, v := range project.ToolProfiles {
+		merged.ToolProfiles[k] = v
+	}
+
+	return merged
+}
+
+// pathExists returns true if the path exists on the filesystem
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// expandHome expands a leading ~ to the given home directory
+func expandHome(path, homeDir string) string {
+	if path == "~" {
+		return homeDir
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(homeDir, path[2:])
+	}
+	return path
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,242 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"qoliber/magebox/internal/config"
+)
+
+func TestBuildArgs_DefaultClaude(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	// Create paths that the builder checks for
+	mustCreate(t, filepath.Join(home, ".claude"))
+	mustCreate(t, filepath.Join(home, ".cache"))
+	mustCreateFile(t, filepath.Join(home, ".claude.json"))
+	mustCreateFile(t, filepath.Join(home, ".bashrc"))
+	mustCreateFile(t, filepath.Join(home, ".gitconfig"))
+
+	mgr := NewManager(home, project)
+	profile := ResolveProfile("claude", nil)
+	opts := Options{Profile: profile}
+
+	args := mgr.BuildArgs("claude", nil, opts)
+	joined := strings.Join(args, " ")
+
+	// Should have basic sandbox setup
+	assertContains(t, joined, "--tmpfs /tmp")
+	assertContains(t, joined, "--dev /dev")
+	assertContains(t, joined, "--proc /proc")
+	assertContains(t, joined, "--hostname magebox-sandbox --unshare-uts")
+
+	// Should bind project dir read-write
+	assertContains(t, joined, "--bind "+project+" "+project)
+
+	// Should bind ~/.claude read-write
+	assertContains(t, joined, "--bind "+filepath.Join(home, ".claude")+" "+filepath.Join(home, ".claude"))
+
+	// Should bind ~/.cache read-write
+	assertContains(t, joined, "--bind "+filepath.Join(home, ".cache")+" "+filepath.Join(home, ".cache"))
+
+	// Should bind ~/.claude.json read-write
+	assertContains(t, joined, "--bind "+filepath.Join(home, ".claude.json")+" "+filepath.Join(home, ".claude.json"))
+
+	// Should bind user configs read-only
+	assertContains(t, joined, "--ro-bind "+filepath.Join(home, ".bashrc")+" "+filepath.Join(home, ".bashrc"))
+	assertContains(t, joined, "--ro-bind "+filepath.Join(home, ".gitconfig")+" "+filepath.Join(home, ".gitconfig"))
+
+	// Should end with claude --dangerously-skip-permissions
+	assertContains(t, joined, "claude --dangerously-skip-permissions")
+}
+
+func TestBuildArgs_SkipsNonExistentPaths(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	// Don't create any user config files
+	mgr := NewManager(home, project)
+	profile := ToolProfile{
+		Command:    "claude",
+		ConfigDirs: []string{"~/.nonexistent-dir"},
+	}
+	opts := Options{Profile: profile}
+
+	args := mgr.BuildArgs("claude", nil, opts)
+	joined := strings.Join(args, " ")
+
+	// Should NOT contain nonexistent paths
+	if strings.Contains(joined, ".nonexistent-dir") {
+		t.Error("should skip non-existent config dirs")
+	}
+	if strings.Contains(joined, ".bashrc") {
+		t.Error("should skip non-existent user config files")
+	}
+}
+
+func TestBuildArgs_CustomToolArgs(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	mgr := NewManager(home, project)
+	profile := ToolProfile{
+		Command: "claude",
+		Args:    []string{"--dangerously-skip-permissions"},
+	}
+	opts := Options{Profile: profile}
+
+	// When explicit args are provided, they should replace defaults
+	args := mgr.BuildArgs("claude", []string{"--resume"}, opts)
+	joined := strings.Join(args, " ")
+
+	assertContains(t, joined, "claude --resume")
+	if strings.Contains(joined, "--dangerously-skip-permissions") {
+		t.Error("explicit tool args should override default args")
+	}
+}
+
+func TestBuildArgs_ExtraBinds(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	// Create the extra bind path
+	sshDir := filepath.Join(home, ".ssh")
+	mustCreate(t, sshDir)
+	composerDir := filepath.Join(home, ".composer")
+	mustCreate(t, composerDir)
+
+	mgr := NewManager(home, project)
+	profile := ToolProfile{Command: "claude"}
+	opts := Options{
+		Profile:      profile,
+		ExtraROBinds: []string{"~/.ssh"},
+		ExtraBinds:   []string{"~/.composer"},
+	}
+
+	args := mgr.BuildArgs("claude", nil, opts)
+	joined := strings.Join(args, " ")
+
+	assertContains(t, joined, "--ro-bind "+sshDir+" "+sshDir)
+	assertContains(t, joined, "--bind "+composerDir+" "+composerDir)
+}
+
+func TestResolveProfile_Defaults(t *testing.T) {
+	profile := ResolveProfile("claude", nil)
+
+	if profile.Command != "claude" {
+		t.Errorf("expected command 'claude', got %q", profile.Command)
+	}
+	if len(profile.Args) != 1 || profile.Args[0] != "--dangerously-skip-permissions" {
+		t.Errorf("unexpected default args: %v", profile.Args)
+	}
+}
+
+func TestResolveProfile_UnknownTool(t *testing.T) {
+	profile := ResolveProfile("my-custom-tool", nil)
+
+	if profile.Command != "my-custom-tool" {
+		t.Errorf("expected command 'my-custom-tool', got %q", profile.Command)
+	}
+	if len(profile.Args) != 0 {
+		t.Errorf("unknown tool should have no default args, got %v", profile.Args)
+	}
+}
+
+func TestResolveProfile_ConfigOverride(t *testing.T) {
+	cfg := &config.SandboxConfig{
+		ToolProfiles: map[string]config.SandboxToolProfile{
+			"claude": {
+				Args: []string{"--model", "opus"},
+			},
+		},
+	}
+
+	profile := ResolveProfile("claude", cfg)
+
+	if profile.Command != "claude" {
+		t.Errorf("command should remain 'claude', got %q", profile.Command)
+	}
+	if len(profile.Args) != 2 || profile.Args[0] != "--model" {
+		t.Errorf("args should be overridden, got %v", profile.Args)
+	}
+	// ConfigDirs should still have defaults since not overridden
+	if len(profile.ConfigDirs) != 2 {
+		t.Errorf("config dirs should retain defaults, got %v", profile.ConfigDirs)
+	}
+}
+
+func TestMergeSandboxConfigs(t *testing.T) {
+	global := &config.SandboxConfig{
+		DefaultTool:  "claude",
+		ExtraROBinds: []string{"~/.ssh"},
+	}
+	project := &config.SandboxConfig{
+		DefaultTool: "codex",
+		ExtraBinds:  []string{"~/.composer"},
+	}
+
+	merged := MergeSandboxConfigs(global, project)
+
+	if merged.DefaultTool != "codex" {
+		t.Errorf("project default_tool should override global, got %q", merged.DefaultTool)
+	}
+	if len(merged.ExtraROBinds) != 1 || merged.ExtraROBinds[0] != "~/.ssh" {
+		t.Errorf("global ro binds should carry over, got %v", merged.ExtraROBinds)
+	}
+	if len(merged.ExtraBinds) != 1 || merged.ExtraBinds[0] != "~/.composer" {
+		t.Errorf("project binds should carry over, got %v", merged.ExtraBinds)
+	}
+}
+
+func TestMergeSandboxConfigs_BothNil(t *testing.T) {
+	merged := MergeSandboxConfigs(nil, nil)
+	if merged == nil {
+		t.Error("merged config should not be nil")
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	tests := []struct {
+		input    string
+		home     string
+		expected string
+	}{
+		{"~/.claude", "/home/user", "/home/user/.claude"},
+		{"~", "/home/user", "/home/user"},
+		{"/etc/hosts", "/home/user", "/etc/hosts"},
+		{"relative/path", "/home/user", "relative/path"},
+	}
+
+	for _, tt := range tests {
+		result := expandHome(tt.input, tt.home)
+		if result != tt.expected {
+			t.Errorf("expandHome(%q, %q) = %q, want %q", tt.input, tt.home, result, tt.expected)
+		}
+	}
+}
+
+// Helpers
+
+func mustCreate(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", path, err)
+	}
+}
+
+func mustCreateFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+		t.Fatalf("failed to create file %s: %v", path, err)
+	}
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected to contain %q, got:\n%s", needle, haystack)
+	}
+}

--- a/internal/sandbox/tools.go
+++ b/internal/sandbox/tools.go
@@ -1,0 +1,70 @@
+package sandbox
+
+import "qoliber/magebox/internal/config"
+
+// ToolProfile holds the resolved sandbox profile for a tool
+type ToolProfile struct {
+	Command     string
+	Args        []string
+	ConfigDirs  []string
+	ConfigFiles []string
+}
+
+// defaultProfiles returns the built-in tool profiles
+func defaultProfiles() map[string]ToolProfile {
+	return map[string]ToolProfile{
+		"claude": {
+			Command:     "claude",
+			Args:        []string{"--dangerously-skip-permissions"},
+			ConfigDirs:  []string{"~/.claude", "~/.cache"},
+			ConfigFiles: []string{"~/.claude.json"},
+		},
+		"codex": {
+			Command:    "codex",
+			Args:       []string{},
+			ConfigDirs: []string{"~/.codex", "~/.cache"},
+		},
+	}
+}
+
+// ResolveProfile returns a merged tool profile for the given tool name,
+// combining built-in defaults with any config overrides.
+func ResolveProfile(name string, cfg *config.SandboxConfig) ToolProfile {
+	defaults := defaultProfiles()
+	profile, ok := defaults[name]
+	if !ok {
+		// Unknown tool: use the name as command with no special config
+		profile = ToolProfile{
+			Command: name,
+		}
+	}
+
+	if cfg == nil {
+		return profile
+	}
+
+	cfgProfiles := cfg.ToolProfiles
+	if cfgProfiles == nil {
+		return profile
+	}
+
+	override, ok := cfgProfiles[name]
+	if !ok {
+		return profile
+	}
+
+	if override.Command != "" {
+		profile.Command = override.Command
+	}
+	if len(override.Args) > 0 {
+		profile.Args = override.Args
+	}
+	if len(override.ConfigDirs) > 0 {
+		profile.ConfigDirs = override.ConfigDirs
+	}
+	if len(override.ConfigFiles) > 0 {
+		profile.ConfigFiles = override.ConfigFiles
+	}
+
+	return profile
+}


### PR DESCRIPTION
Launches AI coding agents (claude, codex) inside a bwrap sandbox that restricts filesystem access to the project directory and tool config dirs. Supports configurable tool profiles, extra bind mounts, and dry-run mode. Unknown flags pass through to the tool so e.g. `magebox sandbox claude --resume` works.