### PR TITLE
Add FAQ: composer patches hanging on macOS

### DIFF
--- a/vitepress/guide/faq.md
+++ b/vitepress/guide/faq.md
@@ -251,6 +251,8 @@ The `cweagans/composer-patches` plugin runs `patch -p1 -d vendor/<package>/`, wh
 
 Strip the `vendor/<package>/` prefix from the `---` and `+++` lines, as well as from the `diff --git` header line if present.
 
+**Alternative:** Consider switching to [`vaimo/composer-patches`](https://github.com/vaimo/composer-patches), which is generally considered a better option and runs `patch` in batch mode (`-t`) so it fails cleanly instead of hanging.
+
 ---
 
 ## Linux Specific


### PR DESCRIPTION
## Summary

- Adds a new FAQ entry under "macOS Specific" explaining why `composer install` hangs when applying patches via `cweagans/composer-patches`
- Documents the root cause: BSD `patch` on macOS prompts interactively when file paths don't resolve, unlike GNU `patch` on Linux which tries harder to find files
- Provides the fix: strip `vendor/<package>/` prefix from patch file paths

## Context

MageBox runs PHP natively on macOS, so `composer install` uses the macOS BSD `patch` binary. Docker-based tools (DDEV, Warden) run inside Linux containers where GNU `patch` is more forgiving with incorrect paths. This is a common gotcha when migrating projects from Docker-based setups to MageBox.