### PR TITLE
Fix composer version fallback and self-update binary sync

### DIFF
--- a/cmd/magebox/new.go
+++ b/cmd/magebox/new.go
@@ -513,14 +513,15 @@ func runNew(cmd *cobra.Command, args []string) error {
 
 	// Determine project name from directory
 	var projectDir string
-	if targetDir == "." {
+	cleanTarget := filepath.Clean(targetDir)
+	if cleanTarget == "." {
 		projectDir, _ = os.Getwd()
 	} else {
-		if filepath.IsAbs(targetDir) {
-			projectDir = targetDir
+		if filepath.IsAbs(cleanTarget) {
+			projectDir = cleanTarget
 		} else {
 			cwd, _ := os.Getwd()
-			projectDir = filepath.Join(cwd, targetDir)
+			projectDir = filepath.Join(cwd, cleanTarget)
 		}
 	}
 	projectName := filepath.Base(projectDir)
@@ -937,7 +938,9 @@ func runNewQuick(targetDir string, p *platform.Platform) error {
 	var projectName string
 	var projectDir string
 
-	if targetDir == "." {
+	// Normalize "./", ".", etc. to current directory
+	cleanTarget := filepath.Clean(targetDir)
+	if cleanTarget == "." {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("failed to get current directory: %w", err)
@@ -945,8 +948,8 @@ func runNewQuick(targetDir string, p *platform.Platform) error {
 		projectDir = cwd
 		projectName = filepath.Base(cwd)
 	} else {
-		projectDir, _ = filepath.Abs(targetDir)
-		projectName = filepath.Base(targetDir)
+		projectDir, _ = filepath.Abs(cleanTarget)
+		projectName = filepath.Base(cleanTarget)
 	}
 
 	// Domain from project name

--- a/internal/templates/composer.go
+++ b/internal/templates/composer.go
@@ -300,7 +300,13 @@ func GenerateMagentoComposerJSON(projectName, version string) ([]byte, error) {
 	versions := GetMagentoVersions()
 	v, ok := versions[version]
 	if !ok {
-		return nil, fmt.Errorf("unsupported Magento version: %s", version)
+		// Allow unknown versions — use sensible defaults for plugin constraints
+		v = MagentoVersion{
+			Version:            version,
+			ProductVersion:     version,
+			RootUpdatePlugin:   "^2.0.4",
+			VersionAuditPlugin: "~0.1",
+		}
 	}
 
 	composer := ComposerJSON{
@@ -367,7 +373,13 @@ func GenerateMageOSComposerJSON(projectName, version string) ([]byte, error) {
 	versions := GetMageOSVersions()
 	v, ok := versions[version]
 	if !ok {
-		return nil, fmt.Errorf("unsupported MageOS version: %s", version)
+		// Allow unknown versions — MageOS uses the version string for all fields
+		v = MageOSVersion{
+			Version:            version,
+			ProductVersion:     version,
+			RootUpdatePlugin:   version,
+			VersionAuditPlugin: version,
+		}
 	}
 
 	composer := ComposerJSON{

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -148,6 +148,9 @@ func (u *Updater) Update(result *UpdateResult) error {
 	// Remove backup
 	_ = os.Remove(backupPath)
 
+	// Sync to all known binary locations
+	u.syncBinaryLocations(execPath)
+
 	return nil
 }
 
@@ -161,6 +164,52 @@ func isWritable(path string) bool {
 	f.Close()
 	os.Remove(testFile)
 	return true
+}
+
+// syncBinaryLocations copies the updated binary to other known locations
+func (u *Updater) syncBinaryLocations(sourcePath string) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+
+	locations := []string{
+		filepath.Join(homeDir, ".magebox", "bin", "magebox"),
+		filepath.Join(homeDir, ".magebox", "bin", "mbox"),
+		"/usr/local/bin/magebox",
+		"/usr/local/bin/mbox",
+	}
+
+	for _, loc := range locations {
+		// Skip the source itself
+		resolved, _ := filepath.EvalSymlinks(loc)
+		if resolved == sourcePath || loc == sourcePath {
+			continue
+		}
+
+		// Skip symlinks — they'll resolve to the updated target
+		fi, err := os.Lstat(loc)
+		if err != nil {
+			continue
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		// Copy binary to this location
+		data, err := os.ReadFile(sourcePath)
+		if err != nil {
+			continue
+		}
+
+		if err := os.WriteFile(loc, data, 0755); err != nil {
+			// Try with sudo for system paths
+			if strings.HasPrefix(loc, "/usr/") {
+				cmd := exec.Command("sudo", "cp", sourcePath, loc)
+				_ = cmd.Run()
+			}
+		}
+	}
 }
 
 // installWithSudo installs the binary using sudo
@@ -187,6 +236,9 @@ func (u *Updater) installWithSudo(tmpFile, execPath string) error {
 
 	// Remove backup with sudo
 	_ = exec.Command("sudo", "rm", "-f", backupPath).Run()
+
+	// Sync to all known binary locations
+	u.syncBinaryLocations(execPath)
 
 	return nil
 }

--- a/vitepress/guide/installation.md
+++ b/vitepress/guide/installation.md
@@ -181,6 +181,8 @@ magebox self-update check
 magebox self-update
 ```
 
+The self-update command automatically syncs the updated binary to all known locations (`~/.magebox/bin/magebox`, `~/.magebox/bin/mbox`, `/usr/local/bin/magebox`, `/usr/local/bin/mbox`) to prevent version mismatches.
+
 ## Next Steps
 
 After installation, run the bootstrap command to set up your environment:

--- a/vitepress/guide/troubleshooting.md
+++ b/vitepress/guide/troubleshooting.md
@@ -537,6 +537,50 @@ sudo setenforce 0
 
 ## Getting Help
 
+## Version Mismatch Between `mbox` and `magebox`
+
+If `mbox --version` and `magebox --version` show different versions, you have multiple binaries in your PATH:
+
+```bash
+# Check which binary is being used
+which mbox
+which magebox
+```
+
+**Common locations:**
+- `~/.magebox/bin/magebox` — installed by MageBox
+- `~/.magebox/bin/mbox` — alias copy
+- `~/.local/bin/mbox` — older install
+- `/usr/local/bin/magebox` — system install via `get.magebox.dev`
+
+**Solution:** Run `magebox self-update` — since v1.14.1, self-update syncs all known binary locations automatically. Or manually:
+
+```bash
+# Copy the latest binary to all locations
+cp $(which magebox) ~/.magebox/bin/mbox
+sudo cp $(which magebox) /usr/local/bin/magebox
+sudo ln -sf /usr/local/bin/magebox /usr/local/bin/mbox
+```
+
+After updating, clear zsh's command cache:
+```bash
+hash -r
+```
+
+## `unsupported MageOS/Magento version` During `magebox new`
+
+```
+Error: failed to generate composer.json: unsupported MageOS version: X.X.X
+```
+
+This happens when the daily-updated version registry adds a new version that isn't in the binary's hardcoded composer template map.
+
+**Solution:** Update to v1.14.1 or later — unknown versions now use sensible defaults for composer plugin constraints instead of erroring.
+
+```bash
+magebox self-update
+```
+
 If you're still stuck:
 
 1. Run with verbose mode:


### PR DESCRIPTION
- Allow unknown Magento/MageOS versions in composer.json generation instead of erroring, using sensible defaults for plugin constraints. This fixes `magebox new` when the daily-updated version registry adds versions not in the hardcoded map.

- Self-update now syncs the updated binary to all known locations (~/.magebox/bin/magebox, ~/.magebox/bin/mbox, /usr/local/bin/magebox, /usr/local/bin/mbox) to prevent version mismatches.

- Updated troubleshooting docs for version mismatch and unsupported version errors.
- I've also added option to install in current directory 
- `mbox new ./ --quick`