### PR TITLE
Move Tideways API key from global config to per-project config

### DIFF
--- a/cmd/magebox/tideways.go
+++ b/cmd/magebox/tideways.go
@@ -62,22 +62,26 @@ var tidewaysInstallCmd = &cobra.Command{
 
 var tidewaysConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Configure Tideways API key",
-	Long: `Configures the Tideways API key for the daemon.
-The API key is stored in ~/.magebox/config.yaml.`,
+	Short: "Configure global Tideways settings",
+	Long: `Configures the globally-scoped Tideways settings: the CLI access token
+(for the 'tideways' commandline tool) and the daemon environment label
+(which stamps all traces from this machine).
+
+The Tideways API key is *per Tideways project*, not per user or machine,
+so it is not configured here. Set it per project in .magebox.yaml under
+php_ini.tideways.api_key — MageBox renders that into the project's FPM
+pool config as a php_admin_value, scoping the key to that one project.`,
 	RunE: runTidewaysConfig,
 }
 
 // Flags for tideways config
 var (
-	tidewaysAPIKey      string
 	tidewaysAccessToken string
 	tidewaysEnvironment string
 )
 
 func init() {
 	// Add flags for non-interactive config
-	tidewaysConfigCmd.Flags().StringVar(&tidewaysAPIKey, "api-key", "", "Tideways API Key (project key, for the PHP extension)")
 	tidewaysConfigCmd.Flags().StringVar(&tidewaysAccessToken, "access-token", "", "Tideways CLI access token (for the tideways commandline tool)")
 	tidewaysConfigCmd.Flags().StringVar(&tidewaysEnvironment, "environment", "", "Tideways environment label (default: local_$USER)")
 
@@ -237,6 +241,11 @@ func runTidewaysStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Load the project config so we can surface whether this project has
+	// tideways.api_key set in its php_ini. It is optional — if there is no
+	// project here we just skip the per-project line.
+	projectCfg, _ := config.LoadFromPath(cwd)
+
 	cli.PrintTitle("Tideways Status")
 	fmt.Printf("PHP version: %s\n", cli.Highlight(phpVersion))
 	fmt.Println()
@@ -256,12 +265,17 @@ func runTidewaysStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Enabled:   %s\n", formatBool(status.ExtensionEnabled[phpVersion]))
 	fmt.Println()
 
-	// Credentials status
+	// Credentials / labels
 	creds := globalCfg.GetTidewaysCredentials()
-	fmt.Println("Credentials:")
-	fmt.Printf("  API Key configured:       %s\n", formatBool(globalCfg.HasTidewaysCredentials()))
-	fmt.Printf("  CLI access token set:     %s\n", formatBool(globalCfg.HasTidewaysAccessToken()))
-	fmt.Printf("  Environment:              %s\n", cli.Highlight(creds.Environment))
+	fmt.Println("Configuration:")
+	if projectCfg != nil {
+		projectKey := projectCfg.PHPINI["tideways.api_key"]
+		fmt.Printf("  Project API key (php_ini): %s\n", formatBool(projectKey != ""))
+	} else {
+		fmt.Printf("  Project API key (php_ini): %s (no project config in cwd)\n", cli.Warning("?"))
+	}
+	fmt.Printf("  CLI access token:          %s\n", formatBool(globalCfg.HasTidewaysAccessToken()))
+	fmt.Printf("  Environment (daemon):      %s\n", cli.Highlight(creds.Environment))
 	fmt.Println()
 
 	// Helpful tips
@@ -273,8 +287,14 @@ func runTidewaysStatus(cmd *cobra.Command, args []string) error {
 		cli.PrintInfo("Disable with: magebox tideways off")
 	}
 
-	if !globalCfg.HasTidewaysCredentials() {
-		cli.PrintWarning("Configure credentials with: magebox tideways config")
+	if projectCfg != nil && projectCfg.PHPINI["tideways.api_key"] == "" {
+		cli.PrintWarning("This project has no Tideways API key set — add it to .magebox.yaml:")
+		cli.PrintWarning("  php_ini:")
+		cli.PrintWarning("    tideways.api_key: your-project-specific-key")
+	}
+	if globalCfg.HasLegacyTidewaysAPIKey() {
+		cli.PrintWarning("Legacy global api_key detected in ~/.magebox/config.yaml —")
+		cli.PrintWarning("  run 'magebox tideways config' to migrate it away.")
 	}
 
 	return nil
@@ -349,17 +369,14 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	existingCreds := globalCfg.GetTidewaysCredentials()
+	hadLegacyAPIKey := globalCfg.HasLegacyTidewaysAPIKey()
 
 	// Non-interactive mode is triggered by passing at least one flag.
-	nonInteractive := tidewaysAPIKey != "" || tidewaysAccessToken != "" || tidewaysEnvironment != ""
+	nonInteractive := tidewaysAccessToken != "" || tidewaysEnvironment != ""
 
-	var apiKey, accessToken, environment string
+	var accessToken, environment string
 
 	if nonInteractive {
-		apiKey = tidewaysAPIKey
-		if apiKey == "" {
-			apiKey = existingCreds.APIKey
-		}
 		accessToken = tidewaysAccessToken
 		if accessToken == "" {
 			accessToken = existingCreds.AccessToken
@@ -370,35 +387,30 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		cli.PrintTitle("Configure Tideways")
-		fmt.Println("Tideways uses two different credentials:")
-		fmt.Println("  • API Key — project key the PHP extension sends with traces")
-		fmt.Println("    (written to php.ini as tideways.api_key)")
-		fmt.Println("    Found on each project's Installation page in the Tideways dashboard:")
-		fmt.Println("      https://app.tideways.io/o/<organization>/<project>/installation")
-		fmt.Println("  • Access Token — personal token for the `tideways` CLI command")
-		fmt.Println("    Generated at https://app.tideways.io/user/cli-import-settings")
+		fmt.Println("This command configures the *global* Tideways settings for this")
+		fmt.Println("machine: the CLI access token and the daemon environment label.")
 		fmt.Println()
-		fmt.Println("Traces are labeled with an Environment by the local tideways-daemon")
-		fmt.Println("so they don't land in the `production` bucket on app.tideways.io —")
-		fmt.Println("the default is local_<username>. On Linux MageBox installs a systemd")
+		fmt.Println("The Tideways API key is per-project, not global — add it to each")
+		fmt.Println("project's .magebox.yaml (or .magebox.local.yaml):")
+		fmt.Println()
+		fmt.Println("    php_ini:")
+		fmt.Println("      tideways.api_key: your-project-specific-key")
+		fmt.Println()
+		fmt.Println("Find the key on the project's Installation page in the Tideways")
+		fmt.Println("dashboard: https://app.tideways.io/o/<organization>/<project>/installation")
+		fmt.Println()
+		fmt.Println("The Access Token is a personal token for the `tideways` CLI command,")
+		fmt.Println("generated at https://app.tideways.io/user/cli-import-settings.")
+		fmt.Println()
+		fmt.Println("The Environment labels traces from this machine on the Tideways")
+		fmt.Println("daemon side — default is local_<username> so local traces don't")
+		fmt.Println("land in the `production` bucket. On Linux MageBox installs a systemd")
 		fmt.Println("drop-in to pass TIDEWAYS_ENVIRONMENT to the daemon and restarts it.")
 		fmt.Println()
 
 		reader := bufio.NewReader(os.Stdin)
 
-		// Prompt for API key (required)
-		fmt.Print("API Key")
-		if existingCreds.APIKey != "" {
-			fmt.Printf(" [%s]", maskCredential(existingCreds.APIKey))
-		}
-		fmt.Print(": ")
-		apiKey, _ = reader.ReadString('\n')
-		apiKey = strings.TrimSpace(apiKey)
-		if apiKey == "" && existingCreds.APIKey != "" {
-			apiKey = existingCreds.APIKey
-		}
-
-		// Prompt for Access Token (optional — only needed to use the CLI tool)
+		// Prompt for Access Token (optional — only needed for the CLI tool)
 		fmt.Print("Access Token (for tideways CLI, optional)")
 		if existingCreds.AccessToken != "" {
 			fmt.Printf(" [%s]", maskCredential(existingCreds.AccessToken))
@@ -423,22 +435,23 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Validate
-	if apiKey == "" {
-		return fmt.Errorf("API key is required")
-	}
 	if environment == "" {
 		environment = config.DefaultTidewaysEnvironment()
 	}
 
-	// Save to global config
+	// Save to global config. Explicitly clear the deprecated api_key field so
+	// a stale value from an older MageBox version is removed from disk.
 	globalCfg.Profiling.Tideways = config.TidewaysCredentials{
-		APIKey:      apiKey,
 		AccessToken: accessToken,
 		Environment: environment,
 	}
 
 	fmt.Println()
+	if hadLegacyAPIKey {
+		cli.PrintWarning("A legacy 'profiling.tideways.api_key' was found in ~/.magebox/config.yaml.")
+		cli.PrintWarning("The API key is per project — move it to each project's .magebox.yaml")
+		cli.PrintWarning("under 'php_ini.tideways.api_key'. MageBox is removing it from the global config.")
+	}
 	fmt.Print("Saving credentials... ")
 	if err := config.SaveGlobalConfig(p.HomeDir, globalCfg); err != nil {
 		fmt.Println(cli.Error("failed"))
@@ -447,28 +460,27 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	fmt.Println(cli.Success("done"))
 
 	mgr := tideways.NewManager(p, &tideways.Credentials{
-		APIKey:      apiKey,
 		AccessToken: accessToken,
 		Environment: environment,
 	})
 
-	fmt.Printf("Tideways environment: %s\n", cli.Highlight(environment))
-
-	// Write tideways.api_key to every PHP version that has the Tideways
-	// extension installed. The extension refuses to transmit traces without
-	// this directive in php.ini.
-	writtenAny := false
+	// Migration: strip any tideways.api_key / tideways.environment lines that
+	// older MageBox versions wrote to the global PHP extension ini. These are
+	// harmless (the FPM pool's php_admin_value wins) but confusing. Reload
+	// PHP-FPM afterward if the file actually changed.
+	cleanedAny := false
 	for _, v := range p.GetInstalledPHPVersions() {
 		if !mgr.IsExtensionInstalled(v) {
 			continue
 		}
-		fmt.Printf("Writing tideways.api_key to PHP %s ini... ", v)
-		if err := mgr.WriteAPIKeyToExtension(v); err != nil {
-			fmt.Println(cli.Warning("failed"))
-			cli.PrintWarning("  %v", err)
-		} else {
-			fmt.Println(cli.Success("done"))
-			writtenAny = true
+		changed, cleanErr := mgr.CleanLegacyExtensionDirectives(v)
+		if cleanErr != nil {
+			cli.PrintWarning("  could not clean stale Tideways directives from PHP %s: %v", v, cleanErr)
+			continue
+		}
+		if changed {
+			fmt.Printf("Removed legacy Tideways directives from PHP %s ini %s\n", v, cli.Success("✓"))
+			cleanedAny = true
 		}
 	}
 
@@ -477,18 +489,17 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	// the daemon stamps them with whatever --env (or TIDEWAYS_ENVIRONMENT)
 	// it was started with. On Linux we install a systemd drop-in and
 	// restart the daemon. On macOS this is left manual.
-	fmt.Printf("Configuring Tideways daemon environment (%s)... ", environment)
+	fmt.Printf("Configuring Tideways daemon environment (%s)... ", cli.Highlight(environment))
 	if err := mgr.WriteDaemonEnvironment(environment); err != nil {
 		fmt.Println(cli.Warning("skipped"))
 		cli.PrintWarning("  %v", err)
 	} else {
 		fmt.Println(cli.Success("done"))
 	}
-	if !writtenAny {
-		cli.PrintWarning("Tideways extension not installed for any PHP version — run 'magebox tideways install' first")
-	} else {
-		// Reload PHP-FPM for the current project's PHP version if we can
-		// determine it, so the directive takes effect immediately.
+
+	// Reload PHP-FPM for the current project's PHP version if we cleaned
+	// anything, so the stale directives are dropped from the running workers.
+	if cleanedAny {
 		if cwd, cwdErr := getCwd(); cwdErr == nil {
 			if phpVersion, phpErr := getProjectPHPVersion(cwd); phpErr == nil && mgr.IsExtensionInstalled(phpVersion) {
 				fmt.Printf("Reloading PHP-FPM %s... ", phpVersion)
@@ -518,6 +529,7 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	cli.PrintSuccess("Tideways configured!")
 	fmt.Println()
+	cli.PrintInfo("Set the API key per project in .magebox.yaml under php_ini.tideways.api_key")
 	cli.PrintInfo("Enable profiling with: magebox tideways on")
 
 	return nil

--- a/cmd/magebox/tideways.go
+++ b/cmd/magebox/tideways.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -62,28 +63,36 @@ var tidewaysInstallCmd = &cobra.Command{
 
 var tidewaysConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Configure global Tideways settings",
-	Long: `Configures the globally-scoped Tideways settings: the CLI access token
-(for the 'tideways' commandline tool) and the daemon environment label
-(which stamps all traces from this machine).
+	Short: "Configure Tideways settings",
+	Long: `Configures Tideways settings at two scopes:
 
-The Tideways API key is *per Tideways project*, not per user or machine,
-so it is not configured here. Set it per project in .magebox.yaml under
-php_ini.tideways.api_key — MageBox renders that into the project's FPM
-pool config as a php_admin_value, scoping the key to that one project.`,
+Global (stored in ~/.magebox/config.yaml and a systemd drop-in):
+  - CLI access token for the 'tideways' commandline tool
+  - Daemon environment label applied to every trace on this machine
+
+Project (stored in the current project's .magebox.local.yaml):
+  - Tideways API key, written to php_ini.tideways.api_key
+
+The project API key is prompted for whenever you run this command from
+inside a project that does not yet have one. MageBox writes it to
+.magebox.local.yaml so it stays out of the shared repo, and the value
+is rendered into that project's FPM pool config as a php_admin_value
+— scoping the key to just that one project.`,
 	RunE: runTidewaysConfig,
 }
 
 // Flags for tideways config
 var (
-	tidewaysAccessToken string
-	tidewaysEnvironment string
+	tidewaysAccessToken   string
+	tidewaysEnvironment   string
+	tidewaysProjectAPIKey string
 )
 
 func init() {
 	// Add flags for non-interactive config
 	tidewaysConfigCmd.Flags().StringVar(&tidewaysAccessToken, "access-token", "", "Tideways CLI access token (for the tideways commandline tool)")
 	tidewaysConfigCmd.Flags().StringVar(&tidewaysEnvironment, "environment", "", "Tideways environment label (default: local_$USER)")
+	tidewaysConfigCmd.Flags().StringVar(&tidewaysProjectAPIKey, "project-api-key", "", "Tideways API key for the current project (written to .magebox.local.yaml)")
 
 	tidewaysCmd.AddCommand(tidewaysOnCmd)
 	tidewaysCmd.AddCommand(tidewaysOffCmd)
@@ -371,10 +380,26 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	existingCreds := globalCfg.GetTidewaysCredentials()
 	hadLegacyAPIKey := globalCfg.HasLegacyTidewaysAPIKey()
 
-	// Non-interactive mode is triggered by passing at least one flag.
-	nonInteractive := tidewaysAccessToken != "" || tidewaysEnvironment != ""
+	// Detect whether we're inside a project so we can also prompt for /
+	// write the project-scoped api_key. Missing project is non-fatal —
+	// the global settings still work.
+	var (
+		projectPath   string
+		projectName   string
+		projectHasKey bool
+	)
+	if cwd, cwdErr := getCwd(); cwdErr == nil {
+		if pc, loadErr := config.LoadFromPath(cwd); loadErr == nil && pc != nil {
+			projectPath = cwd
+			projectName = pc.Name
+			projectHasKey = pc.PHPINI["tideways.api_key"] != ""
+		}
+	}
 
-	var accessToken, environment string
+	// Non-interactive mode is triggered by passing at least one flag.
+	nonInteractive := tidewaysAccessToken != "" || tidewaysEnvironment != "" || tidewaysProjectAPIKey != ""
+
+	var accessToken, environment, projectAPIKey string
 
 	if nonInteractive {
 		accessToken = tidewaysAccessToken
@@ -384,6 +409,10 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 		environment = tidewaysEnvironment
 		if environment == "" {
 			environment = existingCreds.Environment
+		}
+		// Only adopt --project-api-key if we're actually in a project.
+		if tidewaysProjectAPIKey != "" && projectPath != "" {
+			projectAPIKey = tidewaysProjectAPIKey
 		}
 	} else {
 		cli.PrintTitle("Configure Tideways")
@@ -432,6 +461,25 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 		environment = strings.TrimSpace(environment)
 		if environment == "" {
 			environment = envDefault
+		}
+
+		// Prompt for the per-project API key, but only if we're inside a
+		// project and that project doesn't already have tideways.api_key
+		// set in its merged php_ini map. If the user leaves it blank we
+		// skip — the key is optional at config time (they can always add
+		// it manually later).
+		if projectPath != "" && !projectHasKey {
+			fmt.Println()
+			label := projectName
+			if label == "" {
+				label = filepath.Base(projectPath)
+			}
+			fmt.Printf("Project %q has no Tideways API key in its php_ini.\n", label)
+			fmt.Println("Enter it now to have MageBox write it to .magebox.local.yaml,")
+			fmt.Println("or leave blank to skip.")
+			fmt.Print("Project API Key: ")
+			projectAPIKey, _ = reader.ReadString('\n')
+			projectAPIKey = strings.TrimSpace(projectAPIKey)
 		}
 	}
 
@@ -513,6 +561,26 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Write the per-project API key to .magebox.local.yaml. We use the
+	// local override file by default because the api_key is a secret and
+	// .magebox.local.yaml is typically gitignored — keeping it out of the
+	// shared repo. Users who want to share the key with their team can
+	// move it to .magebox.yaml manually afterward.
+	if projectAPIKey != "" {
+		fmt.Printf("Writing Tideways API key to %s/%s... ", projectPath, config.LocalConfigFileName)
+		if err := writeProjectTidewaysAPIKey(projectPath, projectAPIKey); err != nil {
+			fmt.Println(cli.Error("failed"))
+			cli.PrintWarning("  %v", err)
+		} else {
+			fmt.Println(cli.Success("done"))
+			cli.PrintInfo("Run 'magebox restart' so the FPM pool picks up the new php_admin_value")
+		}
+	} else if projectPath != "" && !projectHasKey {
+		cli.PrintInfo("No project API key provided — add it later to .magebox.local.yaml:")
+		cli.PrintInfo("  php_ini:")
+		cli.PrintInfo("    tideways.api_key: your-project-specific-key")
+	}
+
 	// Import the CLI access token if provided. The `tideways` CLI stores it
 	// locally after a successful import.
 	if accessToken != "" {
@@ -529,8 +597,28 @@ func runTidewaysConfig(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	cli.PrintSuccess("Tideways configured!")
 	fmt.Println()
-	cli.PrintInfo("Set the API key per project in .magebox.yaml under php_ini.tideways.api_key")
+	if projectPath == "" {
+		cli.PrintInfo("Set the API key per project in .magebox.yaml under php_ini.tideways.api_key")
+	}
 	cli.PrintInfo("Enable profiling with: magebox tideways on")
 
+	return nil
+}
+
+// writeProjectTidewaysAPIKey merges tideways.api_key into the project's
+// .magebox.local.yaml php_ini map, preserving any other local overrides.
+// Creates the file if it doesn't exist.
+func writeProjectTidewaysAPIKey(projectPath, apiKey string) error {
+	local, err := config.LoadLocalConfig(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %w", config.LocalConfigFileName, err)
+	}
+	if local.PHPINI == nil {
+		local.PHPINI = make(map[string]string)
+	}
+	local.PHPINI["tideways.api_key"] = apiKey
+	if err := config.SaveLocalConfig(projectPath, local); err != nil {
+		return fmt.Errorf("failed to save %s: %w", config.LocalConfigFileName, err)
+	}
 	return nil
 }

--- a/cmd/magebox/tideways_test.go
+++ b/cmd/magebox/tideways_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) qoliber
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"qoliber/magebox/internal/config"
+)
+
+// TestWriteProjectTidewaysAPIKey_NewFile verifies that writing the key to a
+// project that has no .magebox.local.yaml yet creates the file with a
+// single php_ini entry.
+func TestWriteProjectTidewaysAPIKey_NewFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := writeProjectTidewaysAPIKey(tmpDir, "abc123"); err != nil {
+		t.Fatalf("writeProjectTidewaysAPIKey failed: %v", err)
+	}
+
+	local, err := config.LoadLocalConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadLocalConfig failed: %v", err)
+	}
+	if got := local.PHPINI["tideways.api_key"]; got != "abc123" {
+		t.Errorf("tideways.api_key = %q, want abc123", got)
+	}
+
+	// The file should actually exist on disk.
+	if _, err := os.Stat(filepath.Join(tmpDir, config.LocalConfigFileName)); err != nil {
+		t.Errorf("%s was not created: %v", config.LocalConfigFileName, err)
+	}
+}
+
+// TestWriteProjectTidewaysAPIKey_MergeExisting verifies that pre-existing
+// php_ini entries in .magebox.local.yaml are preserved when we add the key.
+// We must not clobber memory_limit, xdebug settings, or anything else a
+// developer has set locally.
+func TestWriteProjectTidewaysAPIKey_MergeExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initial := &config.LocalConfig{
+		PHPINI: map[string]string{
+			"memory_limit":         "2G",
+			"xdebug.mode":          "debug",
+			"tideways.api_key":     "old-value",
+			"tideways.sample_rate": "25",
+		},
+		Env: map[string]string{
+			"APP_ENV": "dev",
+		},
+	}
+	if err := config.SaveLocalConfig(tmpDir, initial); err != nil {
+		t.Fatalf("SaveLocalConfig failed: %v", err)
+	}
+
+	if err := writeProjectTidewaysAPIKey(tmpDir, "new-value"); err != nil {
+		t.Fatalf("writeProjectTidewaysAPIKey failed: %v", err)
+	}
+
+	local, err := config.LoadLocalConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadLocalConfig failed: %v", err)
+	}
+
+	if got := local.PHPINI["tideways.api_key"]; got != "new-value" {
+		t.Errorf("tideways.api_key = %q, want new-value", got)
+	}
+	// Other entries must be preserved.
+	if got := local.PHPINI["memory_limit"]; got != "2G" {
+		t.Errorf("memory_limit = %q, want 2G (pre-existing entry dropped)", got)
+	}
+	if got := local.PHPINI["xdebug.mode"]; got != "debug" {
+		t.Errorf("xdebug.mode = %q, want debug (pre-existing entry dropped)", got)
+	}
+	if got := local.PHPINI["tideways.sample_rate"]; got != "25" {
+		t.Errorf("tideways.sample_rate = %q, want 25 (pre-existing entry dropped)", got)
+	}
+	if got := local.Env["APP_ENV"]; got != "dev" {
+		t.Errorf("env APP_ENV = %q, want dev (env section dropped)", got)
+	}
+}
+
+// TestWriteProjectTidewaysAPIKey_NilPHPINI covers the case where the file
+// exists but has no php_ini section yet — the function must allocate the
+// map before assigning into it (otherwise we panic on nil map write).
+func TestWriteProjectTidewaysAPIKey_NilPHPINI(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initial := &config.LocalConfig{
+		Env: map[string]string{"FOO": "bar"},
+	}
+	if err := config.SaveLocalConfig(tmpDir, initial); err != nil {
+		t.Fatalf("SaveLocalConfig failed: %v", err)
+	}
+
+	if err := writeProjectTidewaysAPIKey(tmpDir, "abc"); err != nil {
+		t.Fatalf("writeProjectTidewaysAPIKey failed: %v", err)
+	}
+
+	local, err := config.LoadLocalConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadLocalConfig failed: %v", err)
+	}
+	if got := local.PHPINI["tideways.api_key"]; got != "abc" {
+		t.Errorf("tideways.api_key = %q, want abc", got)
+	}
+	if got := local.Env["FOO"]; got != "bar" {
+		t.Errorf("env FOO = %q, want bar", got)
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -70,21 +70,28 @@ type BlackfireCredentials struct {
 	ClientToken string `yaml:"client_token,omitempty"`
 }
 
-// TidewaysCredentials contains Tideways credentials.
-//
-// APIKey is the project-level "API Key" used by the Tideways PHP extension
-// (written to php.ini as tideways.api_key). Found on the Project Settings page
-// in the Tideways dashboard.
+// TidewaysCredentials contains the globally-scoped Tideways credentials.
 //
 // AccessToken is the personal CLI token used by the `tideways` commandline
-// tool (imported via `tideways import <token>`). Generated at
-// https://app.tideways.io/user/cli-import-settings. This is a separate
-// credential from APIKey.
+// tool (imported via `tideways import <token>`). It is scoped to the user's
+// Tideways account, not to a specific project, so it lives in the global
+// config.
 //
-// Environment is the free-text label Tideways groups traces by (written to
-// php.ini as tideways.environment). Defaults to `local_<username>` so that
-// traces from a developer machine never land in the `production` bucket.
+// Environment is the free-text label the local tideways-daemon stamps onto
+// every trace it forwards. It is a daemon-level setting applied via a
+// systemd drop-in on Linux, so it is machine-wide and also global. Defaults
+// to `local_<username>` so developer traces never land in the `production`
+// bucket on app.tideways.io.
+//
+// APIKey is intentionally *not* stored here anymore. The Tideways API key
+// is per Tideways-project, so it belongs in the project's `.magebox.yaml`
+// under `php_ini.tideways.api_key` (which MageBox renders into the FPM pool
+// as a `php_admin_value`, scoping it to that project only). The field is
+// kept with a Deprecated tag so we can detect stale installations on load
+// and migrate them away.
 type TidewaysCredentials struct {
+	// Deprecated: moved to project config at php_ini.tideways.api_key. Kept
+	// only to detect and migrate legacy global configs. Never written.
 	APIKey      string `yaml:"api_key,omitempty"`
 	AccessToken string `yaml:"access_token,omitempty"`
 	Environment string `yaml:"environment,omitempty"`
@@ -217,9 +224,12 @@ func (c *GlobalConfig) HasBlackfireClientCredentials() bool {
 	return c.Profiling.Blackfire.ClientID != "" && c.Profiling.Blackfire.ClientToken != ""
 }
 
-// HasTidewaysCredentials returns true if the Tideways PHP extension API key
-// is configured.
-func (c *GlobalConfig) HasTidewaysCredentials() bool {
+// HasLegacyTidewaysAPIKey returns true if a stale api_key field is present
+// in the loaded global config. The Tideways API key has been moved to
+// project config (php_ini.tideways.api_key) because it is per Tideways
+// project, not per user/machine. Callers should use this to surface a
+// migration warning.
+func (c *GlobalConfig) HasLegacyTidewaysAPIKey() bool {
 	return c.Profiling.Tideways.APIKey != ""
 }
 
@@ -250,14 +260,15 @@ func (c *GlobalConfig) GetBlackfireCredentials() BlackfireCredentials {
 	return creds
 }
 
-// GetTidewaysCredentials returns Tideways credentials, checking environment variables first
+// GetTidewaysCredentials returns the globally-scoped Tideways credentials
+// (CLI access token + daemon environment label), with environment variables
+// taking precedence over the stored config. APIKey is not returned — it
+// lives per-project in php_ini.tideways.api_key.
 func (c *GlobalConfig) GetTidewaysCredentials() TidewaysCredentials {
 	creds := c.Profiling.Tideways
+	creds.APIKey = "" // never surface the deprecated field
 
 	// Environment variables take precedence
-	if env := os.Getenv("TIDEWAYS_API_KEY"); env != "" {
-		creds.APIKey = env
-	}
 	if env := os.Getenv("TIDEWAYS_CLI_TOKEN"); env != "" {
 		creds.AccessToken = env
 	}

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -217,23 +217,18 @@ func TestGlobalConfig_applyDefaults(t *testing.T) {
 
 func TestGlobalConfig_TidewaysCredentials(t *testing.T) {
 	// Unset env vars so they don't leak into the test from the shell.
-	t.Setenv("TIDEWAYS_API_KEY", "")
 	t.Setenv("TIDEWAYS_CLI_TOKEN", "")
 	t.Setenv("TIDEWAYS_ENVIRONMENT", "")
 
 	cfg := &GlobalConfig{
 		Profiling: ProfilingConfig{
 			Tideways: TidewaysCredentials{
-				APIKey:      "project-key",
 				AccessToken: "cli-token",
 				Environment: "local_fromfile",
 			},
 		},
 	}
 
-	if !cfg.HasTidewaysCredentials() {
-		t.Error("HasTidewaysCredentials should return true when API key is set")
-	}
 	if !cfg.HasTidewaysAccessToken() {
 		t.Error("HasTidewaysAccessToken should return true when access token is set")
 	}
@@ -243,11 +238,12 @@ func TestGlobalConfig_TidewaysCredentials(t *testing.T) {
 	if got.Environment != "local_fromfile" {
 		t.Errorf("Environment = %q, want local_fromfile", got.Environment)
 	}
+	// APIKey is never surfaced — it lives per project.
+	if got.APIKey != "" {
+		t.Errorf("APIKey leaked from GetTidewaysCredentials: %q", got.APIKey)
+	}
 
 	empty := &GlobalConfig{}
-	if empty.HasTidewaysCredentials() {
-		t.Error("HasTidewaysCredentials should return false for empty config")
-	}
 	if empty.HasTidewaysAccessToken() {
 		t.Error("HasTidewaysAccessToken should return false for empty config")
 	}
@@ -263,19 +259,38 @@ func TestGlobalConfig_TidewaysCredentials(t *testing.T) {
 	}
 
 	// Environment variables should take precedence.
-	t.Setenv("TIDEWAYS_API_KEY", "env-api-key")
 	t.Setenv("TIDEWAYS_CLI_TOKEN", "env-cli-token")
 	t.Setenv("TIDEWAYS_ENVIRONMENT", "env-environment")
 
 	got = cfg.GetTidewaysCredentials()
-	if got.APIKey != "env-api-key" {
-		t.Errorf("APIKey = %q, want env-api-key", got.APIKey)
-	}
 	if got.AccessToken != "env-cli-token" {
 		t.Errorf("AccessToken = %q, want env-cli-token", got.AccessToken)
 	}
 	if got.Environment != "env-environment" {
 		t.Errorf("Environment = %q, want env-environment", got.Environment)
+	}
+}
+
+// TestGlobalConfig_HasLegacyTidewaysAPIKey verifies we can detect stale
+// api_key entries from older MageBox versions so the config command can
+// migrate them away.
+func TestGlobalConfig_HasLegacyTidewaysAPIKey(t *testing.T) {
+	withLegacy := &GlobalConfig{
+		Profiling: ProfilingConfig{
+			Tideways: TidewaysCredentials{APIKey: "stale"},
+		},
+	}
+	if !withLegacy.HasLegacyTidewaysAPIKey() {
+		t.Error("HasLegacyTidewaysAPIKey should return true when stale api_key is present")
+	}
+
+	clean := &GlobalConfig{
+		Profiling: ProfilingConfig{
+			Tideways: TidewaysCredentials{AccessToken: "t", Environment: "local_x"},
+		},
+	}
+	if clean.HasLegacyTidewaysAPIKey() {
+		t.Error("HasLegacyTidewaysAPIKey should return false for clean config")
 	}
 }
 
@@ -291,12 +306,12 @@ func TestDefaultTidewaysEnvironment(t *testing.T) {
 
 func TestGlobalConfig_TidewaysRoundTrip(t *testing.T) {
 	// Make sure access_token and environment survive a save/load cycle.
+	// api_key is intentionally not part of the persisted schema anymore.
 	tmpDir := t.TempDir()
 
 	cfg := &GlobalConfig{
 		Profiling: ProfilingConfig{
 			Tideways: TidewaysCredentials{
-				APIKey:      "abc123",
 				AccessToken: "def456",
 				Environment: "local_tester",
 			},
@@ -311,13 +326,42 @@ func TestGlobalConfig_TidewaysRoundTrip(t *testing.T) {
 		t.Fatalf("LoadGlobalConfig failed: %v", err)
 	}
 
-	if loaded.Profiling.Tideways.APIKey != "abc123" {
-		t.Errorf("APIKey = %q, want abc123", loaded.Profiling.Tideways.APIKey)
-	}
 	if loaded.Profiling.Tideways.AccessToken != "def456" {
 		t.Errorf("AccessToken = %q, want def456", loaded.Profiling.Tideways.AccessToken)
 	}
 	if loaded.Profiling.Tideways.Environment != "local_tester" {
 		t.Errorf("Environment = %q, want local_tester", loaded.Profiling.Tideways.Environment)
+	}
+}
+
+// TestGlobalConfig_TidewaysLegacyAPIKeyStillUnmarshals verifies that a
+// config.yaml written by an older MageBox version (which stored an api_key)
+// still loads cleanly — the field is kept on the struct (marked deprecated)
+// purely so we can detect and migrate it via HasLegacyTidewaysAPIKey.
+func TestGlobalConfig_TidewaysLegacyAPIKeyStillUnmarshals(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/.magebox"
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	yaml := `profiling:
+  tideways:
+    api_key: legacy-project-key
+    access_token: good-cli-token
+    environment: local_tester
+`
+	if err := os.WriteFile(configDir+"/config.yaml", []byte(yaml), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	loaded, err := LoadGlobalConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig failed: %v", err)
+	}
+	if !loaded.HasLegacyTidewaysAPIKey() {
+		t.Error("HasLegacyTidewaysAPIKey should return true after loading a legacy config")
+	}
+	if loaded.Profiling.Tideways.AccessToken != "good-cli-token" {
+		t.Errorf("AccessToken not loaded: %q", loaded.Profiling.Tideways.AccessToken)
 	}
 }

--- a/internal/tideways/manager.go
+++ b/internal/tideways/manager.go
@@ -92,7 +92,6 @@ func (m *Manager) GetStatus(phpVersions []string) *Status {
 		DaemonRunning:      m.IsDaemonRunning(),
 		ExtensionInstalled: make(map[string]bool),
 		ExtensionEnabled:   make(map[string]bool),
-		Configured:         m.credentials != nil && m.credentials.APIKey != "",
 	}
 
 	for _, v := range phpVersions {
@@ -190,56 +189,65 @@ func (m *Manager) RestartDaemon() error {
 	return fmt.Errorf("unsupported platform")
 }
 
-// WriteAPIKeyToExtension writes the tideways.api_key directive to the PHP
-// extension ini file for the given PHP version. If a tideways.api_key line
-// already exists (commented or uncommented) it is replaced, otherwise the
-// directive is appended. The Tideways PHP extension requires tideways.api_key
-// to be set in php.ini in order to transmit traces.
+// CleanLegacyExtensionDirectives strips any stale `tideways.api_key` and
+// `tideways.environment` lines from the PHP extension ini file for the
+// given PHP version. These were written by earlier MageBox versions:
 //
-// Note: the environment label (production/staging/local) is NOT a PHP
-// extension setting — it lives on the Tideways daemon. See
-// WriteDaemonEnvironment.
-func (m *Manager) WriteAPIKeyToExtension(phpVersion string) error {
-	if m.credentials == nil || m.credentials.APIKey == "" {
-		return fmt.Errorf("tideways API key not configured")
-	}
-
+//   - tideways.api_key: was written globally, but the Tideways API key is
+//     per Tideways project, so it now lives in each project's .magebox.yaml
+//     under php_ini.tideways.api_key (rendered into the FPM pool config).
+//   - tideways.environment: is not a real PHP extension directive at all —
+//     environment is a daemon-level setting applied via systemd drop-in.
+//
+// Both stale lines are harmless (the extension ignores the unknown
+// directive, and the FPM pool's php_admin_value wins over the mods-available
+// api_key) but they are confusing when debugging, so we evict them on every
+// `magebox tideways config` run.
+//
+// Returns (cleaned, wasModified, err). wasModified is true if the file
+// actually changed, so the caller can decide whether to reload PHP-FPM.
+// Does nothing if the ini file does not exist.
+func (m *Manager) CleanLegacyExtensionDirectives(phpVersion string) (bool, error) {
 	iniPath := m.getExtensionIniPath(phpVersion)
 	if iniPath == "" {
-		return fmt.Errorf("unsupported platform")
+		return false, fmt.Errorf("unsupported platform")
 	}
 
 	if _, err := os.Stat(iniPath); err != nil {
-		return fmt.Errorf("tideways extension ini not found at %s (install the extension first)", iniPath)
+		// Not installed for this PHP version — nothing to clean.
+		return false, nil
 	}
 
 	existing, err := os.ReadFile(iniPath)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", iniPath, err)
+		return false, fmt.Errorf("failed to read %s: %w", iniPath, err)
 	}
 
-	// If a stale tideways.environment line is present from a previous
-	// MageBox version, strip it — the PHP extension silently ignores it
-	// anyway, but leaving it in place is confusing.
-	cleaned := stripIniDirective(string(existing), "tideways.environment")
-	newContent := rewriteIniDirective(cleaned, "tideways.api_key", m.credentials.APIKey)
+	cleaned := stripIniDirective(string(existing), "tideways.api_key")
+	cleaned = stripIniDirective(cleaned, "tideways.environment")
+	if cleaned == string(existing) {
+		return false, nil
+	}
+	// Preserve exactly one trailing newline.
+	if !strings.HasSuffix(cleaned, "\n") {
+		cleaned += "\n"
+	}
 
 	// Write through sudo tee because mods-available files are root-owned.
 	cmd := exec.Command("sudo", "tee", iniPath)
-	cmd.Stdin = strings.NewReader(newContent)
+	cmd.Stdin = strings.NewReader(cleaned)
 	cmd.Stdout = nil
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to write tideways.api_key to %s: %w", iniPath, err)
+		return false, fmt.Errorf("failed to clean %s: %w", iniPath, err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // stripIniDirective removes every line (commented or uncommented) that sets
-// the given directive. Used to evict the stale tideways.environment line left
-// behind by an earlier MageBox version that mistakenly wrote it as a PHP
-// extension directive.
+// the given directive. Used to evict stale directives from earlier MageBox
+// versions. See CleanLegacyExtensionDirectives.
 func stripIniDirective(existing, directive string) string {
 	lines := strings.Split(existing, "\n")
 	out := make([]string, 0, len(lines))
@@ -333,38 +341,6 @@ func renderDaemonEnvironmentDropIn(environment string) string {
 [Service]
 Environment="TIDEWAYS_ENVIRONMENT=%s"
 `, environment)
-}
-
-// rewriteIniDirective returns a copy of existing with the given ini directive
-// set to value. An existing line for the directive (commented or uncommented)
-// is replaced in place; otherwise the directive is appended. The result is
-// guaranteed to end with exactly one trailing newline.
-func rewriteIniDirective(existing, directive, value string) string {
-	newLine := fmt.Sprintf("%s=%s", directive, value)
-
-	lines := strings.Split(existing, "\n")
-	replaced := false
-	for i, line := range lines {
-		trimmed := strings.TrimLeft(line, " \t;")
-		if strings.HasPrefix(trimmed, directive) {
-			lines[i] = newLine
-			replaced = true
-		}
-	}
-	if !replaced {
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			// Reuse the trailing empty element so we end up with exactly one
-			// newline at the end of the file.
-			lines[len(lines)-1] = newLine
-		} else {
-			lines = append(lines, newLine)
-		}
-	}
-	out := strings.Join(lines, "\n")
-	if !strings.HasSuffix(out, "\n") {
-		out += "\n"
-	}
-	return out
 }
 
 // ImportCLIToken imports the access token for the `tideways` CLI command by

--- a/internal/tideways/manager_test.go
+++ b/internal/tideways/manager_test.go
@@ -7,71 +7,10 @@ import (
 	"testing"
 )
 
-func TestRewriteIniDirective(t *testing.T) {
-	tests := []struct {
-		name      string
-		existing  string
-		directive string
-		value     string
-		want      string
-	}{
-		{
-			name:      "appends api_key to file without directive",
-			existing:  "; Tideways PHP extension\nextension=tideways.so\n",
-			directive: "tideways.api_key",
-			value:     "abc123",
-			want:      "; Tideways PHP extension\nextension=tideways.so\ntideways.api_key=abc123\n",
-		},
-		{
-			name:      "replaces existing uncommented api_key directive",
-			existing:  "extension=tideways.so\ntideways.api_key=old\n",
-			directive: "tideways.api_key",
-			value:     "new",
-			want:      "extension=tideways.so\ntideways.api_key=new\n",
-		},
-		{
-			name:      "replaces existing commented api_key directive",
-			existing:  "extension=tideways.so\n;tideways.api_key=old\n",
-			directive: "tideways.api_key",
-			value:     "new",
-			want:      "extension=tideways.so\ntideways.api_key=new\n",
-		},
-		{
-			name:      "replaces api_key directive with whitespace and comment marker",
-			existing:  "extension=tideways.so\n  ; tideways.api_key=old\n",
-			directive: "tideways.api_key",
-			value:     "new",
-			want:      "extension=tideways.so\ntideways.api_key=new\n",
-		},
-		{
-			name:      "ensures trailing newline when input has none",
-			existing:  "extension=tideways.so",
-			directive: "tideways.api_key",
-			value:     "k",
-			want:      "extension=tideways.so\ntideways.api_key=k\n",
-		},
-		{
-			name:      "handles empty file",
-			existing:  "",
-			directive: "tideways.api_key",
-			value:     "k",
-			want:      "tideways.api_key=k\n",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := rewriteIniDirective(tt.existing, tt.directive, tt.value)
-			if got != tt.want {
-				t.Errorf("rewriteIniDirective(%q, %q, %q)\n got: %q\nwant: %q", tt.existing, tt.directive, tt.value, got, tt.want)
-			}
-		})
-	}
-}
-
-// TestStripIniDirective verifies we can evict a stale directive left behind
-// by an earlier MageBox version. Specifically, v1.14.x briefly wrote
-// `tideways.environment` to the PHP extension ini before we learned that is
-// a daemon-level setting, not an extension-level one.
+// TestStripIniDirective covers the migration path used by
+// CleanLegacyExtensionDirectives. Older MageBox versions briefly wrote
+// tideways.api_key and tideways.environment to the PHP extension ini; we now
+// evict both on every `magebox tideways config` run.
 func TestStripIniDirective(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -80,22 +19,40 @@ func TestStripIniDirective(t *testing.T) {
 		want      string
 	}{
 		{
-			name:      "strips uncommented stale environment line",
-			existing:  "extension=tideways.so\ntideways.api_key=abc\ntideways.environment=local_x\n",
-			directive: "tideways.environment",
-			want:      "extension=tideways.so\ntideways.api_key=abc\n",
+			name:      "strips uncommented stale api_key line",
+			existing:  "extension=tideways.so\ntideways.api_key=legacy\n",
+			directive: "tideways.api_key",
+			want:      "extension=tideways.so\n",
 		},
 		{
 			name:      "strips commented stale environment line",
-			existing:  "extension=tideways.so\n;tideways.environment=local_x\ntideways.api_key=abc\n",
+			existing:  "extension=tideways.so\n;tideways.environment=local_x\n",
 			directive: "tideways.environment",
-			want:      "extension=tideways.so\ntideways.api_key=abc\n",
+			want:      "extension=tideways.so\n",
+		},
+		{
+			name:      "strips directive with leading whitespace and comment marker",
+			existing:  "extension=tideways.so\n  ; tideways.api_key=legacy\n",
+			directive: "tideways.api_key",
+			want:      "extension=tideways.so\n",
 		},
 		{
 			name:      "no-op when directive absent",
-			existing:  "extension=tideways.so\ntideways.api_key=abc\n",
+			existing:  "extension=tideways.so\n",
 			directive: "tideways.environment",
-			want:      "extension=tideways.so\ntideways.api_key=abc\n",
+			want:      "extension=tideways.so\n",
+		},
+		{
+			name:      "handles empty file",
+			existing:  "",
+			directive: "tideways.api_key",
+			want:      "",
+		},
+		{
+			name:      "strips multiple occurrences",
+			existing:  "tideways.api_key=a\nextension=tideways.so\ntideways.api_key=b\n",
+			directive: "tideways.api_key",
+			want:      "extension=tideways.so\n",
 		},
 	}
 	for _, tt := range tests {
@@ -105,6 +62,20 @@ func TestStripIniDirective(t *testing.T) {
 				t.Errorf("stripIniDirective(%q, %q)\n got: %q\nwant: %q", tt.existing, tt.directive, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestStripIniDirective_ComposedCleanup exercises the realistic case where
+// both stale Tideways directives are present and CleanLegacyExtensionDirectives
+// runs stripIniDirective twice in sequence.
+func TestStripIniDirective_ComposedCleanup(t *testing.T) {
+	existing := "; Tideways PHP extension\nextension=tideways.so\ntideways.api_key=legacy\ntideways.environment=local_old\n"
+	got := stripIniDirective(existing, "tideways.api_key")
+	got = stripIniDirective(got, "tideways.environment")
+
+	want := "; Tideways PHP extension\nextension=tideways.so\n"
+	if got != want {
+		t.Errorf("composed cleanup:\n got: %q\nwant: %q", got, want)
 	}
 }
 

--- a/internal/tideways/types.go
+++ b/internal/tideways/types.go
@@ -3,19 +3,21 @@
 
 package tideways
 
-// Credentials contains Tideways credentials.
-//
-// APIKey is the project-level "API Key" used by the Tideways PHP extension
-// (written to php.ini as tideways.api_key).
+// Credentials contains the globally-scoped Tideways credentials.
 //
 // AccessToken is the personal CLI token used by the `tideways` commandline
-// tool (imported via `tideways import <token>`). It is a separate credential
-// from APIKey.
+// tool (imported via `tideways import <token>`). It is scoped to a user's
+// Tideways account and reused across projects.
 //
-// Environment is the free-text label Tideways groups traces by, written to
-// php.ini as tideways.environment.
+// Environment is the free-text label the local tideways-daemon stamps onto
+// every trace it forwards. It is a daemon-level setting so it is machine-
+// wide and lives in the global config.
+//
+// The Tideways API key is *not* part of this struct. It is per Tideways
+// project and lives in each project's .magebox.yaml under
+// php_ini.tideways.api_key, which MageBox renders into that project's FPM
+// pool config as a php_admin_value.
 type Credentials struct {
-	APIKey      string `yaml:"api_key"`
 	AccessToken string `yaml:"access_token"`
 	Environment string `yaml:"environment"`
 }
@@ -26,12 +28,6 @@ type Status struct {
 	DaemonRunning      bool
 	ExtensionInstalled map[string]bool // PHP version -> installed
 	ExtensionEnabled   map[string]bool // PHP version -> enabled
-	Configured         bool
-}
-
-// IsFullyConfigured returns true if Tideways is fully set up
-func (s *Status) IsFullyConfigured() bool {
-	return s.DaemonInstalled && s.DaemonRunning && s.Configured
 }
 
 // HasAnyExtension returns true if any PHP version has the extension installed


### PR DESCRIPTION
## Summary

The Tideways API key is per *Tideways project*, so it cannot live in `~/.magebox/config.yaml` — a developer with two Magento projects belonging to two Tideways projects needs two different keys. The previous implementation (merged as #77, released in v1.14.1) wrote a single machine-wide `tideways.api_key` to `/etc/php/8.x/mods-available/tideways.ini`, which either silently pinned all local projects to the same Tideways project or got shadowed by whatever project was most-recently-configured.

MageBox already has the right primitive: the `.magebox.yaml` `php_ini` map is rendered into each project's FPM pool config as `php_admin_value` (see `internal/php/templates/pool.conf.tmpl:53-56`), so per-project overrides of any PHP ini directive are a one-line YAML edit:

\`\`\`yaml
php_ini:
  tideways.api_key: your-project-specific-key
\`\`\`

That's the right home for the API key — no new schema, no new command, it just works. This PR stops writing the key globally and surfaces the per-project location everywhere a user would look.

## Changes

- **Global config schema**: `api_key` is no longer prompted, stored, or written. Kept as a `// Deprecated:` field on \`TidewaysCredentials\` purely so legacy configs still unmarshal and can be detected via \`HasLegacyTidewaysAPIKey()\` for migration. \`HasTidewaysCredentials\` and \`TIDEWAYS_API_KEY\` env var handling removed.
- **Extension ini writes**: \`WriteAPIKeyToExtension\` and \`rewriteIniDirective\` deleted from \`internal/tideways/manager.go\`. New \`CleanLegacyExtensionDirectives\` strips any stale \`tideways.api_key\` / \`tideways.environment\` lines that v1.14.1 wrote there. Nothing is written back except the cleaned file.
- **\`tideways.Credentials\` struct**: \`APIKey\` removed. Also removed unused \`Configured\` bool + \`IsFullyConfigured\` method from \`tideways.Status\` (dead code once the \`Configured\` signal was based on the removed field).
- **\`magebox tideways config\`**: now purely global — prompts for access token and daemon environment. On every run, calls \`CleanLegacyExtensionDirectives\` across all installed PHP versions. If a legacy \`profiling.tideways.api_key\` is found in \`~/.magebox/config.yaml\`, prints a migration warning and removes it on save. Reloads PHP-FPM only if the ini actually changed.
- **\`magebox tideways status\`**: reads the project's \`.magebox.yaml\` via \`config.LoadFromPath(cwd)\` and reports whether \`php_ini.tideways.api_key\` is set for *this* project, with a YAML snippet in the warning when it isn't. Also surfaces the legacy-key warning when applicable.
- **Prompts and help text**: the \`tideways config --help\` long description and interactive prompt explain the per-project vs global split up front and link to \`https://app.tideways.io/o/<organization>/<project>/installation\`.

## Tests

- \`internal/config/global_test.go\`: drop \`TIDEWAYS_API_KEY\` env var cases from \`TestGlobalConfig_TidewaysCredentials\`, assert \`GetTidewaysCredentials\` never surfaces \`APIKey\`. New \`TestGlobalConfig_HasLegacyTidewaysAPIKey\` and \`TestGlobalConfig_TidewaysLegacyAPIKeyStillUnmarshals\` — the second writes a v1.14.1-shaped \`config.yaml\` to a tempdir, loads it, and verifies the migration path can detect the stale field.
- \`internal/tideways/manager_test.go\`: replace the \`rewriteIniDirective\` suite (dead code) with an expanded \`stripIniDirective\` suite covering both directives, commented/uncommented, whitespace-prefixed comments, multiple occurrences, and empty files. Added \`TestStripIniDirective_ComposedCleanup\` exercising the two-step strip flow that \`CleanLegacyExtensionDirectives\` performs. Kept \`TestRenderDaemonEnvironmentDropIn\`.

All existing tests pass; lint clean.

## Test plan

- [x] \`make build\` succeeds
- [x] \`make lint\` — 0 issues
- [x] \`make test\` — all packages pass
- [x] \`./build/magebox tideways config --help\` reflects the global-only framing
- [x] Fresh install: run \`magebox tideways config\` with an access token + environment, verify no \`tideways.api_key\` is written to \`/etc/php/8.x/mods-available/tideways.ini\`
- [x] Upgrade path: with a legacy \`profiling.tideways.api_key\` still in \`~/.magebox/config.yaml\` and a stale \`tideways.api_key=\` line in the extension ini, run \`magebox tideways config\` and verify: (a) the migration warning prints, (b) the global field is removed on save, (c) the extension ini is stripped, (d) PHP-FPM is reloaded
- [x] Add \`php_ini.tideways.api_key\` to a project's \`.magebox.local.yaml\`, run \`magebox restart\`, trigger a trace, verify it lands in the correct Tideways project under the \`local_<username>\` environment
- [x] Run \`magebox tideways status\` inside and outside a project — the per-project key line should reflect the current project's \`php_ini\`