### PR TITLE
Auto-start project on magebox open if not already running

### DIFF
--- a/cmd/magebox/open.go
+++ b/cmd/magebox/open.go
@@ -8,12 +8,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"qoliber/magebox/internal/cli"
+	"qoliber/magebox/internal/project"
 )
 
 var openCmd = &cobra.Command{
 	Use:   "open",
 	Short: "Open project in browser",
-	Long:  "Opens the first domain from .magebox.yaml in the default browser",
+	Long:  "Starts the project if not already running, then opens the first domain from .magebox.yaml in the default browser",
 	RunE:  runOpen,
 }
 
@@ -37,6 +38,19 @@ func runOpen(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	mgr := project.NewManager(p)
+	if !projectFullyRunning(mgr, cwd) {
+		if err := startProject(mgr, cwd, true); err != nil {
+			return err
+		}
+		fmt.Println()
+	}
+
 	domain := cfg.Domains[0]
 	scheme := "https"
 	if !domain.IsSSLEnabled() {
@@ -55,4 +69,23 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	}
 
 	return openCmd.Start()
+}
+
+// projectFullyRunning reports whether all essential services for the project
+// are running. Optional debug tooling (xdebug, blackfire) is ignored: those
+// being disabled is a normal state and should not trigger a start.
+func projectFullyRunning(mgr *project.Manager, projectPath string) bool {
+	status, err := mgr.Status(projectPath)
+	if err != nil {
+		return false
+	}
+	for name, svc := range status.Services {
+		if name == "xdebug" || name == "blackfire" {
+			continue
+		}
+		if !svc.IsRunning {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
`magebox open` now starts the project automatically when it is not running. If everything is already up, the browser  opens immediately without extra output.

It checks if every service is running and starts it if not. Skips optional Xdebug and Blackfire.