### PR TITLE
Fix magebox run shadowing PHP wrapper with system PHP on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to MageBox will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **`magebox run` PHP Version Shadowing on Linux** - `magebox run` no longer prepends `/usr/bin` (the directory of the versioned PHP binary on Linux) to `PATH`, which silently shadowed the `~/.magebox/bin/php` wrapper and made `php` in custom commands resolve to the system default (e.g. `/usr/bin/php` → PHP 8.4). `magebox run` now prepends `~/.magebox/bin` instead, so `php`, `composer`, and `blackfire` in custom commands consistently resolve to the project-aware wrappers and pick the PHP version from `.magebox.yaml`.
-
 ## [1.14.2] - 2026-04-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to MageBox will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`magebox run` PHP Version Shadowing on Linux** - `magebox run` no longer prepends `/usr/bin` (the directory of the versioned PHP binary on Linux) to `PATH`, which silently shadowed the `~/.magebox/bin/php` wrapper and made `php` in custom commands resolve to the system default (e.g. `/usr/bin/php` → PHP 8.4). `magebox run` now prepends `~/.magebox/bin` instead, so `php`, `composer`, and `blackfire` in custom commands consistently resolve to the project-aware wrappers and pick the PHP version from `.magebox.yaml`.
+
 ## [1.14.2] - 2026-04-10
 
 ### Changed

--- a/cmd/magebox/run.go
+++ b/cmd/magebox/run.go
@@ -169,10 +169,18 @@ func runCustomCommand(cmd *cobra.Command, args []string) error {
 		cmdToRun = cmdToRun + " " + strings.Join(args[1:], " ")
 	}
 
-	// Set up environment with correct PHP in PATH
-	phpDir := filepath.Dir(version.PHPBinary)
+	// Set up environment with correct PHP in PATH.
+	// Prepend ~/.magebox/bin (where the php/composer/blackfire wrappers live)
+	// so `php` resolves to the project-aware wrapper instead of a system PHP.
+	// On Linux, filepath.Dir(PHPBinary) is /usr/bin, which would shadow the
+	// wrapper and silently run the wrong PHP version.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	wrapperDir := filepath.Join(homeDir, ".magebox", "bin")
 	currentPath := os.Getenv("PATH")
-	newPath := phpDir + string(os.PathListSeparator) + currentPath
+	newPath := wrapperDir + string(os.PathListSeparator) + currentPath
 
 	fmt.Printf("Running: %s\n\n", cmdToRun)
 


### PR DESCRIPTION
## Summary

- `magebox run` prepended `/usr/bin` to `PATH` on Linux (via `filepath.Dir(version.PHPBinary)` where `PHPBinary = /usr/bin/php8.2`), shadowing `~/.magebox/bin/php` and silently running the system PHP instead of the project-pinned version.
- Prepends `~/.magebox/bin` (the wrapper dir) instead — the wrapper already reads `.magebox.yaml` and execs the correct versioned PHP, so intent is preserved and behavior is consistent across Linux and macOS.

Fixes #90.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass
- [x] Manual: on Linux with system PHP 8.4 and project pinned to PHP 8.2, `magebox run <cmd>` where `<cmd>` invokes `php bin/magento deploy:mode:set developer` resolves to the project PHP and all Magento commands register
- [ ] Manual: same check on macOS — behavior unchanged (still picks the project PHP via the wrapper)