### PR TITLE
Fix PHP-FPM pool group lookup when primary group name differs from username

### DIFF
--- a/internal/php/pool.go
+++ b/internal/php/pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -373,32 +374,45 @@ func (g *PoolGenerator) renderPool(cfg PoolConfig) (string, error) {
 
 // getCurrentUser returns the current user
 func getCurrentUser() string {
-	user := os.Getenv("USER")
-	if user == "" {
-		user = os.Getenv("LOGNAME")
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		return u.Username
 	}
-	if user == "" {
-		user = "www-data"
+	name := os.Getenv("USER")
+	if name == "" {
+		name = os.Getenv("LOGNAME")
 	}
-	return user
+	if name == "" {
+		name = "www-data"
+	}
+	return name
 }
 
-// getCurrentGroup returns the current user's primary group
+// getCurrentGroup returns the current user's primary group name.
+//
+// It resolves the group by GID via os/user rather than assuming the group
+// name matches the username. On many Linux distributions those are identical
+// (the USERGROUPS_ENAB / "user private group" convention), but this is not
+// guaranteed — administrators commonly rename the primary group or assign a
+// shared primary group. When that happens, assuming group == username
+// produces a php-fpm pool config that fails to start with
+// "cannot get gid for group 'username'".
 func getCurrentGroup() string {
-	// On macOS, the group is typically "staff"
-	// On Linux, it's usually the username or www-data
-	user := getCurrentUser()
-	if user == "www-data" {
-		return "www-data"
+	u, err := user.Current()
+	if err == nil && u.Gid != "" {
+		if g, gerr := user.LookupGroupId(u.Gid); gerr == nil && g.Name != "" {
+			return g.Name
+		}
 	}
 
-	// Check platform - on macOS use "staff"
+	// Fallbacks if os/user lookup fails (e.g. no nsswitch resolution).
+	name := getCurrentUser()
+	if name == "www-data" {
+		return "www-data"
+	}
 	if runtime.GOOS == "darwin" {
 		return "staff"
 	}
-
-	// On Linux, use the username as the group
-	return user
+	return name
 }
 
 // FPMConfig contains data for generating the master php-fpm.conf


### PR DESCRIPTION
## Summary
- Resolve the PHP-FPM pool `group` via `os/user` + GID lookup instead of assuming the primary group name matches the username
- Route `getCurrentUser()` through `user.Current()` as well, so both resolutions share one source of truth and fall back gracefully

## Why
On Linux, `getCurrentGroup()` returned the username verbatim. That works on distros that follow the "user private group" convention (USERGROUPS_ENAB), but breaks as soon as an admin renames the primary group or assigns a shared one. Concrete failure: a user `john` with primary group `john-doe` gets a generated pool with `group = john`, and php-fpm refuses to start:

```
cannot get gid for group 'john'
```

Because the pool file is regenerated on every `magebox start`, hand-patching it doesn't stick — the fix has to live in core.

## Test plan
- [x] `make lint` (0 issues)
- [x] `make test` (all packages pass, including `internal/php`)
- [ ] Manual verification on a system where `id -un` != `id -gn` (e.g. `john` / `john-doe`): generated pool contains the correct group and `php-fpm` starts cleanly