### PR TITLE
Filter unavailable apt packages during PHP install

### DIFF
--- a/internal/bootstrap/installer/base.go
+++ b/internal/bootstrap/installer/base.go
@@ -79,6 +79,19 @@ func (b *BaseInstaller) CommandExists(name string) bool {
 	return platform.CommandExists(name)
 }
 
+// filterPackages partitions pkgs into those the availability predicate
+// accepts (kept) and those it rejects (dropped), preserving input order.
+func filterPackages(pkgs []string, available func(string) bool) (kept, dropped []string) {
+	for _, p := range pkgs {
+		if available(p) {
+			kept = append(kept, p)
+		} else {
+			dropped = append(dropped, p)
+		}
+	}
+	return
+}
+
 // IsRealComposerInstalled checks if the real Composer binary (not our wrapper) is installed
 func (b *BaseInstaller) IsRealComposerInstalled() bool {
 	wrapperDir := filepath.Join(b.Platform.MageBoxDir(), "bin")

--- a/internal/bootstrap/installer/base_test.go
+++ b/internal/bootstrap/installer/base_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) qoliber
+
+package installer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterPackages(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkgs        []string
+		available   map[string]bool
+		wantKept    []string
+		wantDropped []string
+	}{
+		{
+			name:        "all available",
+			pkgs:        []string{"php8.4-cli", "php8.4-opcache", "php8.4-fpm"},
+			available:   map[string]bool{"php8.4-cli": true, "php8.4-opcache": true, "php8.4-fpm": true},
+			wantKept:    []string{"php8.4-cli", "php8.4-opcache", "php8.4-fpm"},
+			wantDropped: nil,
+		},
+		{
+			name:        "opcache merged into core on 8.5",
+			pkgs:        []string{"php8.5-fpm", "php8.5-cli", "php8.5-opcache", "php8.5-zip"},
+			available:   map[string]bool{"php8.5-fpm": true, "php8.5-cli": true, "php8.5-zip": true},
+			wantKept:    []string{"php8.5-fpm", "php8.5-cli", "php8.5-zip"},
+			wantDropped: []string{"php8.5-opcache"},
+		},
+		{
+			name:        "all missing",
+			pkgs:        []string{"php9.0-cli"},
+			available:   map[string]bool{},
+			wantKept:    nil,
+			wantDropped: []string{"php9.0-cli"},
+		},
+		{
+			name:        "preserves order",
+			pkgs:        []string{"a", "b", "c", "d"},
+			available:   map[string]bool{"a": true, "c": true},
+			wantKept:    []string{"a", "c"},
+			wantDropped: []string{"b", "d"},
+		},
+		{
+			name:        "empty input",
+			pkgs:        nil,
+			available:   map[string]bool{},
+			wantKept:    nil,
+			wantDropped: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pred := func(p string) bool { return tt.available[p] }
+			kept, dropped := filterPackages(tt.pkgs, pred)
+			if !reflect.DeepEqual(kept, tt.wantKept) {
+				t.Errorf("kept = %v, want %v", kept, tt.wantKept)
+			}
+			if !reflect.DeepEqual(dropped, tt.wantDropped) {
+				t.Errorf("dropped = %v, want %v", dropped, tt.wantDropped)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/installer/ubuntu.go
+++ b/internal/bootstrap/installer/ubuntu.go
@@ -19,6 +19,18 @@ type UbuntuInstaller struct {
 	BaseInstaller
 }
 
+// isAptPackageAvailable reports whether an apt package exists in the local
+// apt cache. Used to filter out packages that have been merged into core
+// (e.g. php8.5-opcache is built into php8.5-cli) or otherwise aren't yet
+// published for a given PHP version.
+func isAptPackageAvailable(pkg string) bool {
+	out, err := exec.Command("apt-cache", "show", pkg).Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
 // NewUbuntuInstaller creates a new Ubuntu/Debian installer
 func NewUbuntuInstaller(p *platform.Platform) *UbuntuInstaller {
 	return &UbuntuInstaller{
@@ -113,8 +125,10 @@ func (u *UbuntuInstaller) InstallPHP(version string) error {
 	// www.conf was already disabled by a previous bootstrap run.
 	u.ensurePlaceholderPool(version)
 
-	// Install PHP with all required extensions
-	// Note: sodium is included in php-common on Ubuntu/Debian
+	// Install PHP with all required extensions.
+	// Note: sodium is included in php-common on Ubuntu/Debian. OPcache is a
+	// separate package on 8.1–8.4 but built into php8.5-cli, so we filter
+	// unavailable extension packages out before calling apt.
 	packages := []string{
 		fmt.Sprintf("php%s-fpm", version),
 		fmt.Sprintf("php%s-cli", version),
@@ -130,6 +144,11 @@ func (u *UbuntuInstaller) InstallPHP(version string) error {
 		fmt.Sprintf("php%s-mysql", version),
 		fmt.Sprintf("php%s-soap", version),
 		fmt.Sprintf("php%s-imagick", version),
+	}
+
+	packages, dropped := filterPackages(packages, isAptPackageAvailable)
+	if len(dropped) > 0 {
+		fmt.Printf("  Note: skipping packages not in apt cache (built-in or not packaged for this version): %s\n", strings.Join(dropped, ", "))
 	}
 
 	args := append([]string{"apt", "install", "-y"}, packages...)

--- a/lib/installers/ubuntu.yaml
+++ b/lib/installers/ubuntu.yaml
@@ -38,6 +38,8 @@ php:
       - "php${phpVersion}-cli"
       - "php${phpVersion}-common"
     extensions:
+      # opcache: separate package on 8.1–8.4; built into php8.5-cli
+      # (filtered at install time if missing from the apt cache)
       - "php${phpVersion}-opcache"
       - "php${phpVersion}-zip"
       - "php${phpVersion}-curl"


### PR DESCRIPTION
PHP 8.5 ships OPcache built into php8.5-cli, so the Ondřej PPA no longer publishes a separate php8.5-opcache package. The hardcoded install list caused bootstrap to fail with "Unable to locate package php8.5-opcache" on Ubuntu.

Filter the extension list through apt-cache show before invoking apt install, printing a note for any skipped packages. Self-heals future packaging consolidations without requiring version-specific branches.