### PR TITLE
Prompt for PHP version during magebox init

### DIFF
--- a/cmd/magebox/init_cmd.go
+++ b/cmd/magebox/init_cmd.go
@@ -62,9 +62,15 @@ func runInit(cmd *cobra.Command, args []string) error {
 	// Replace slashes with dots in project name
 	projectName = strings.ReplaceAll(projectName, "/", ".")
 
-	// Prompt for PHP version
+	// Prompt for PHP version. Prefer a version declared in composer.json
+	// (config.platform.php, then require.php) over the global default.
 	defaultPHP := globalCfg.DefaultPHP
-	fmt.Printf("PHP version [%s] (%s): ", cli.Highlight(defaultPHP), strings.Join(php.SupportedVersions, ", "))
+	composerSource := ""
+	if v := php.DetectVersionFromComposer(filepath.Join(cwd, "composer.json")); v != "" {
+		defaultPHP = v
+		composerSource = " (from composer.json)"
+	}
+	fmt.Printf("PHP version [%s%s] (%s): ", cli.Highlight(defaultPHP), composerSource, strings.Join(php.SupportedVersions, ", "))
 	phpInput, _ := reader.ReadString('\n')
 	phpInput = strings.TrimSpace(phpInput)
 	phpVersion := defaultPHP

--- a/cmd/magebox/init_cmd.go
+++ b/cmd/magebox/init_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"qoliber/magebox/internal/cli"
 	"qoliber/magebox/internal/config"
+	"qoliber/magebox/internal/php"
 	"qoliber/magebox/internal/project"
 )
 
@@ -37,16 +38,20 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Load global config once for defaults
+	homeDir, _ := os.UserHomeDir()
+	globalCfg, _ := config.LoadGlobalConfig(homeDir)
+	tld := globalCfg.GetTLD()
+
+	reader := bufio.NewReader(os.Stdin)
+
 	// Determine project name
 	var projectName string
 	if len(args) > 0 {
 		projectName = args[0]
 	} else {
-		// Use directory name
 		projectName = filepath.Base(cwd)
-		// Prompt for confirmation
 		fmt.Printf("Project name [%s]: ", cli.Highlight(projectName))
-		reader := bufio.NewReader(os.Stdin)
 		input, _ := reader.ReadString('\n')
 		input = strings.TrimSpace(input)
 		if input != "" {
@@ -56,6 +61,16 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Replace slashes with dots in project name
 	projectName = strings.ReplaceAll(projectName, "/", ".")
+
+	// Prompt for PHP version
+	defaultPHP := globalCfg.DefaultPHP
+	fmt.Printf("PHP version [%s] (%s): ", cli.Highlight(defaultPHP), strings.Join(php.SupportedVersions, ", "))
+	phpInput, _ := reader.ReadString('\n')
+	phpInput = strings.TrimSpace(phpInput)
+	phpVersion := defaultPHP
+	if phpInput != "" {
+		phpVersion = phpInput
+	}
 
 	// Check if .magebox.yaml already exists
 	configPath := filepath.Join(cwd, config.ConfigFileName)
@@ -70,14 +85,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	mgr := project.NewManager(p)
-	if err := mgr.Init(cwd, projectName, initProjectType); err != nil {
+	if err := mgr.Init(cwd, projectName, initProjectType, phpVersion); err != nil {
 		return err
 	}
-
-	// Get configured TLD
-	homeDir, _ := os.UserHomeDir()
-	globalCfg, _ := config.LoadGlobalConfig(homeDir)
-	tld := globalCfg.GetTLD()
 
 	cli.PrintSuccess("Created %s for project '%s'", config.ConfigFileName, projectName)
 	fmt.Println()

--- a/internal/php/composer.go
+++ b/internal/php/composer.go
@@ -1,0 +1,70 @@
+package php
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+)
+
+// composerJSON is a minimal representation of composer.json for PHP version detection.
+type composerJSON struct {
+	Require map[string]string `json:"require"`
+	Config  struct {
+		Platform map[string]string `json:"platform"`
+	} `json:"config"`
+}
+
+// DetectVersionFromComposer reads composer.json at the given path and returns
+// the PHP version it targets. It prefers an exact pinned version from
+// config.platform.php, falling back to parsing a constraint from require.php
+// (e.g. "~8.3", "^8.2", ">=8.2", "8.2.*"). The returned version is normalized
+// to "MAJOR.MINOR" and is only returned when it matches one of SupportedVersions.
+// An empty string is returned when nothing usable is found.
+func DetectVersionFromComposer(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	var c composerJSON
+	if err := json.Unmarshal(data, &c); err != nil {
+		return ""
+	}
+
+	if v := extractMajorMinor(c.Config.Platform["php"]); isSupportedVersion(v) {
+		return v
+	}
+
+	if c.Require != nil {
+		if v := extractMajorMinor(c.Require["php"]); isSupportedVersion(v) {
+			return v
+		}
+	}
+
+	return ""
+}
+
+// majorMinorRe matches the first "MAJOR.MINOR" occurrence in a version string
+// or Composer constraint. Handles values like "8.3", "8.3.10", "~8.3",
+// "^8.2", ">=8.2", "8.2.*", ">=8.2 <8.4".
+var majorMinorRe = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+func extractMajorMinor(v string) string {
+	m := majorMinorRe.FindStringSubmatch(v)
+	if len(m) < 3 {
+		return ""
+	}
+	return m[1] + "." + m[2]
+}
+
+func isSupportedVersion(v string) bool {
+	if v == "" {
+		return false
+	}
+	for _, sv := range SupportedVersions {
+		if sv == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/php/composer_test.go
+++ b/internal/php/composer_test.go
@@ -1,0 +1,97 @@
+package php
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectVersionFromComposer(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{
+			name:     "platform php pinned",
+			contents: `{"config":{"platform":{"php":"8.3"}}}`,
+			want:     "8.3",
+		},
+		{
+			name:     "platform php with patch",
+			contents: `{"config":{"platform":{"php":"8.2.15"}}}`,
+			want:     "8.2",
+		},
+		{
+			name:     "platform takes precedence over require",
+			contents: `{"config":{"platform":{"php":"8.3"}},"require":{"php":"~8.2"}}`,
+			want:     "8.3",
+		},
+		{
+			name:     "require tilde",
+			contents: `{"require":{"php":"~8.3"}}`,
+			want:     "8.3",
+		},
+		{
+			name:     "require caret",
+			contents: `{"require":{"php":"^8.2"}}`,
+			want:     "8.2",
+		},
+		{
+			name:     "require gte",
+			contents: `{"require":{"php":">=8.2"}}`,
+			want:     "8.2",
+		},
+		{
+			name:     "require wildcard",
+			contents: `{"require":{"php":"8.4.*"}}`,
+			want:     "8.4",
+		},
+		{
+			name:     "require range picks first bound",
+			contents: `{"require":{"php":">=8.2 <8.4"}}`,
+			want:     "8.2",
+		},
+		{
+			name:     "unsupported version ignored",
+			contents: `{"require":{"php":"~7.4"}}`,
+			want:     "",
+		},
+		{
+			name:     "no php entry",
+			contents: `{"require":{"ext-intl":"*"}}`,
+			want:     "",
+		},
+		{
+			name:     "empty object",
+			contents: `{}`,
+			want:     "",
+		},
+		{
+			name:     "invalid json",
+			contents: `{not json`,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "composer.json")
+			if err := os.WriteFile(path, []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("write composer.json: %v", err)
+			}
+			if got := DetectVersionFromComposer(path); got != tt.want {
+				t.Errorf("DetectVersionFromComposer() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectVersionFromComposer_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "composer.json")
+	if got := DetectVersionFromComposer(path); got != "" {
+		t.Errorf("DetectVersionFromComposer() = %q, want empty for missing file", got)
+	}
+}

--- a/internal/project/lifecycle.go
+++ b/internal/project/lifecycle.go
@@ -556,7 +556,7 @@ func (e *PHPNotInstalledError) Error() string {
 }
 
 // Init initializes a new .magebox.yaml file in the given directory
-func (m *Manager) Init(projectPath string, projectName string, projectType string) error {
+func (m *Manager) Init(projectPath string, projectName string, projectType string, phpVersion string) error {
 	configPath := filepath.Join(projectPath, config.ConfigFileName)
 
 	// Check if file already exists
@@ -568,7 +568,6 @@ func (m *Manager) Init(projectPath string, projectName string, projectType strin
 	homeDir, _ := os.UserHomeDir()
 	globalCfg, _ := config.LoadGlobalConfig(homeDir)
 	tld := globalCfg.GetTLD()
-	phpVersion := globalCfg.DefaultPHP
 	defaults := globalCfg.DefaultServices
 
 	// Derive domain from project name

--- a/internal/project/lifecycle_test.go
+++ b/internal/project/lifecycle_test.go
@@ -59,7 +59,7 @@ func TestManager_Init(t *testing.T) {
 		t.Fatalf("failed to create project dir: %v", err)
 	}
 
-	err := m.Init(projectPath, "mystore", "magento")
+	err := m.Init(projectPath, "mystore", "magento", "8.2")
 	if err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
@@ -119,7 +119,7 @@ default_services:
 		t.Fatalf("failed to create project dir: %v", err)
 	}
 
-	err := m.Init(projectPath, "mystore", "magento")
+	err := m.Init(projectPath, "mystore", "magento", "8.4")
 	if err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
@@ -161,12 +161,12 @@ func TestManager_InitAlreadyExists(t *testing.T) {
 	}
 
 	// Create first time
-	if err := m.Init(projectPath, "mystore", "magento"); err != nil {
+	if err := m.Init(projectPath, "mystore", "magento", "8.2"); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 
 	// Try to create again - should fail
-	err := m.Init(projectPath, "mystore", "magento")
+	err := m.Init(projectPath, "mystore", "magento", "8.2")
 	if err == nil {
 		t.Errorf("Init should fail when %s already exists", config.ConfigFileName)
 	}


### PR DESCRIPTION
Adds an interactive PHP version prompt to `magebox init`, defaulting to the value from global config (`default_php`). Supported versions are shown as hints.