### PR TITLE
Raise multitail scrollback buffer to 10000 lines

### DIFF
--- a/cmd/magebox/logs.go
+++ b/cmd/magebox/logs.go
@@ -149,7 +149,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	multitailCmd := exec.Command("multitail",
 		"-s", "2",
 		"-n", "200",
-		"-m", "500",
+		"-m", "10000",
 		systemLog,
 		exceptionLog,
 	)
@@ -379,7 +379,7 @@ func multitailFiles(files []string) error {
 	fmt.Println("Press 'q' to quit, 'b' to scroll back")
 	fmt.Println()
 
-	args := []string{"-n", "200", "-m", "500"}
+	args := []string{"-n", "200", "-m", "10000"}
 	// -s splits into columns; multitail requires the value to be >= 2
 	if len(files) >= 2 {
 		args = append(args, "-s", "2")


### PR DESCRIPTION
## Summary
- Bumps multitail `-m` from 500 to 10000 in both `magebox logs` (system.log/exception.log) and `multitailFiles` (used by `logs php`/`logs nginx`)
- Previous 500-line buffer made `b`-scrollback in multitail nearly useless

## Test plan
- [ ] `magebox logs php` — press `b`, confirm you can page back through more than 500 lines of history
- [ ] `magebox logs` in a Magento project — same check