### PR TITLE
Expose port 3306 only to the global default DB

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -217,15 +217,14 @@ func (g *ComposeGenerator) GenerateGlobalServices(configs []*config.Config) erro
 		}
 	}
 
-	// Determine if there's only one DB service total (always gets standard port)
-	totalDBServices := len(requiredServices.mysql) + len(requiredServices.mariadb)
-	// Determine if there's only one search service total (always gets standard port 9200)
+	// Only the global default DB version gets the standard port 3306.
+	// MySQL default takes precedence over MariaDB default if both are configured.
 	totalSearchServices := len(requiredServices.opensearch) + len(requiredServices.elasticsearch)
 
 	// Add MySQL services
 	for version, svcCfg := range requiredServices.mysql {
 		serviceName := fmt.Sprintf("mysql%s", strings.ReplaceAll(version, ".", ""))
-		addStdPort := (totalDBServices == 1) || (version == defaultMySQL)
+		addStdPort := version == defaultMySQL
 		compose.Services[serviceName] = g.getMySQLService(svcCfg, addStdPort)
 		compose.Volumes[fmt.Sprintf("mysql%s_data", strings.ReplaceAll(version, ".", ""))] = ComposeVolume{}
 	}
@@ -233,7 +232,7 @@ func (g *ComposeGenerator) GenerateGlobalServices(configs []*config.Config) erro
 	// Add MariaDB services
 	for version, svcCfg := range requiredServices.mariadb {
 		serviceName := fmt.Sprintf("mariadb%s", strings.ReplaceAll(version, ".", ""))
-		addStdPort := len(requiredServices.mysql) == 0 && ((totalDBServices == 1) || (version == defaultMariaDB))
+		addStdPort := len(requiredServices.mysql) == 0 && version == defaultMariaDB
 		compose.Services[serviceName] = g.getMariaDBService(svcCfg, addStdPort)
 		compose.Volumes[fmt.Sprintf("mariadb%s_data", strings.ReplaceAll(version, ".", ""))] = ComposeVolume{}
 	}


### PR DESCRIPTION
## Summary
- Bind the standard MySQL port (3306) strictly to the version named by `globalCfg.DefaultServices.MySQL` (or `MariaDB` when no MySQL is configured), instead of also exposing it whenever a single DB service is in play.
- Prevents a `Bind for 0.0.0.0:3306 failed: port is already allocated` error when one project is using e.g. MySQL 5.7 while a default-version container (MySQL 8.0) is still running from another project.

## Test plan
- [ ] `make lint`
- [ ] `make test`
- [ ] With `DefaultServices.MySQL = 8.0`, start a project using MySQL 5.7 while `magebox-mysql-8.0` is running — 5.7 comes up on 33057 only; 8.0 keeps 3306.
- [ ] With only one project running on MySQL 8.0 (matching the default), confirm it still binds both 33080 and 3306.
- [ ] With a project running MariaDB 10.6 (matching `DefaultServices.MariaDB`) and no MySQL configured, confirm it binds 3306.