### PR TITLE
Add auto-managed magerun2 wrapper

### DIFF
--- a/cmd/magebox/bootstrap.go
+++ b/cmd/magebox/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"qoliber/magebox/internal/config"
 	"qoliber/magebox/internal/dns"
 	"qoliber/magebox/internal/docker"
+	"qoliber/magebox/internal/magerunwrapper"
 	"qoliber/magebox/internal/nginx"
 	"qoliber/magebox/internal/php"
 	"qoliber/magebox/internal/phpwrapper"
@@ -831,6 +832,20 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 		if err := wrapperMgr.InstallBlackfire(); err != nil {
 			fmt.Println(cli.Error("failed"))
 			cli.PrintWarning("Blackfire wrapper installation failed: %v", err)
+		} else {
+			fmt.Println(cli.Success("done"))
+		}
+	}
+
+	// magerun2 wrapper (auto-downloads the correct n98-magerun2 phar on first use)
+	magerunMgr := magerunwrapper.NewManager(p)
+	if magerunMgr.IsInstalled() {
+		fmt.Println("  magerun2 wrapper already installed " + cli.Success("✓"))
+	} else {
+		fmt.Print("  Installing magerun2 wrapper script... ")
+		if err := magerunMgr.Install(); err != nil {
+			fmt.Println(cli.Error("failed"))
+			cli.PrintWarning("magerun2 wrapper installation failed: %v", err)
 		} else {
 			fmt.Println(cli.Success("done"))
 		}

--- a/cmd/magebox/check.go
+++ b/cmd/magebox/check.go
@@ -18,6 +18,7 @@ import (
 	"qoliber/magebox/internal/cli"
 	"qoliber/magebox/internal/config"
 	"qoliber/magebox/internal/docker"
+	"qoliber/magebox/internal/magerunwrapper"
 	"qoliber/magebox/internal/nginx"
 	"qoliber/magebox/internal/php"
 	"qoliber/magebox/internal/platform"
@@ -463,6 +464,40 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		printCheckResult(results[len(results)-1])
 		fmt.Println()
 	}
+
+	// Check: magerun2
+	fmt.Println(cli.Header("magerun2"))
+	magerunMgr := magerunwrapper.NewManager(p)
+	if magerunMgr.IsInstalled() {
+		results = append(results, checkResult{
+			name:    "Wrapper",
+			status:  "ok",
+			message: "~/.magebox/bin/magerun2 installed",
+		})
+	} else {
+		results = append(results, checkResult{
+			name:    "Wrapper",
+			status:  "error",
+			message: "Not installed — run 'magebox bootstrap'",
+		})
+	}
+	printCheckResult(results[len(results)-1])
+
+	if cached := magerunMgr.CachedVersion(); cached != "" {
+		results = append(results, checkResult{
+			name:    "Phar",
+			status:  "ok",
+			message: fmt.Sprintf("n98-magerun2 %s installed", cached),
+		})
+	} else {
+		results = append(results, checkResult{
+			name:    "Phar",
+			status:  "warning",
+			message: "Not yet downloaded — will auto-download on first use",
+		})
+	}
+	printCheckResult(results[len(results)-1])
+	fmt.Println()
 
 	// Summary
 	printCheckSummary(results)

--- a/cmd/magebox/magerun.go
+++ b/cmd/magebox/magerun.go
@@ -12,11 +12,20 @@ import (
 	"qoliber/magebox/internal/php"
 )
 
-// magerunBinaries lists the known magerun2 executable names to look for in PATH.
+// magerunBinaries lists the known magerun2 executable names to look for in PATH
+// as a fallback when the MageBox-managed wrapper is not installed.
 var magerunBinaries = []string{"n98-magerun2", "n98-magerun2.phar", "magerun2"}
 
-// findMagerun returns the path to a magerun2 binary if one is available in PATH.
+// findMagerun returns the path to a magerun2 binary. It prefers the
+// MageBox-managed wrapper at ~/.magebox/bin/magerun2, falling back to any
+// magerun2 binary found in PATH.
 func findMagerun() (string, bool) {
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		managed := filepath.Join(homeDir, ".magebox", "bin", "magerun2")
+		if info, err := os.Stat(managed); err == nil && info.Mode().Perm()&0111 != 0 {
+			return managed, true
+		}
+	}
 	for _, name := range magerunBinaries {
 		if path, err := exec.LookPath(name); err == nil {
 			return path, true

--- a/cmd/magebox/magerun_resolve.go
+++ b/cmd/magebox/magerun_resolve.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"qoliber/magebox/internal/magerunwrapper"
+)
+
+var magerunResolveProjectDir string
+
+var magerunResolveCmd = &cobra.Command{
+	Use:    "magerun-resolve",
+	Hidden: true,
+	Short:  "Resolve and ensure the correct n98-magerun2 phar is available",
+	RunE:   runMagerunResolve,
+}
+
+func init() {
+	magerunResolveCmd.Flags().StringVar(&magerunResolveProjectDir, "project-dir", "", "Project directory containing composer.lock")
+	rootCmd.AddCommand(magerunResolveCmd)
+}
+
+func runMagerunResolve(_ *cobra.Command, _ []string) error {
+	p, err := getPlatform()
+	if err != nil {
+		return err
+	}
+
+	mgr := magerunwrapper.NewManager(p)
+	pharPath, err := mgr.Resolve(magerunResolveProjectDir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(pharPath)
+	return nil
+}

--- a/internal/magerunwrapper/downloader.go
+++ b/internal/magerunwrapper/downloader.go
@@ -1,0 +1,117 @@
+package magerunwrapper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	githubReleasesURL = "https://api.github.com/repos/netz98/n98-magerun2/releases/latest"
+	pharDownloadBase  = "https://github.com/netz98/n98-magerun2/releases/download/%s/n98-magerun2.phar"
+	pharSHA256Base    = "https://github.com/netz98/n98-magerun2/releases/download/%s/n98-magerun2.phar.sha256"
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func fetchLatestVersion(client *http.Client) (string, error) {
+	req, err := http.NewRequest("GET", githubReleasesURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "MageBox")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GitHub API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("failed to parse GitHub response: %w", err)
+	}
+
+	return strings.TrimPrefix(rel.TagName, "v"), nil
+}
+
+// verifyPharChecksum downloads the published SHA256 checksum and verifies the
+// phar at pharPath. Returns nil if the checksum file is unavailable (graceful
+// degradation) or if the hash matches.
+func verifyPharChecksum(client *http.Client, pharPath, version string) error {
+	url := fmt.Sprintf(pharSHA256Base, version)
+	resp, err := client.Get(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil // checksum file not published — skip verification
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	// Format is "hexhash  filename" (shasum standard)
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return nil
+	}
+	expected := strings.ToLower(fields[0])
+
+	data, err := os.ReadFile(pharPath)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	actual := hex.EncodeToString(sum[:])
+
+	if actual != expected {
+		return fmt.Errorf("SHA256 mismatch for n98-magerun2 v%s: expected %s, got %s", version, expected, actual)
+	}
+	return nil
+}
+
+func downloadFile(client *http.Client, url, dest string) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".n98-magerun2-*.phar")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, dest)
+}

--- a/internal/magerunwrapper/manager.go
+++ b/internal/magerunwrapper/manager.go
@@ -1,0 +1,215 @@
+package magerunwrapper
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"qoliber/magebox/internal/lib"
+	"qoliber/magebox/internal/platform"
+)
+
+//go:embed templates/magerun2.sh
+var magerun2ScriptEmbed string
+
+func init() {
+	lib.RegisterFallbackTemplate(lib.TemplateWrapper, "magerun2.sh", magerun2ScriptEmbed)
+}
+
+const WrapperName = "magerun2"
+
+// Manager handles n98-magerun2 phar lifecycle and wrapper script installation.
+type Manager struct {
+	platform   *platform.Platform
+	httpClient *http.Client
+}
+
+// NewManager creates a new Manager.
+func NewManager(p *platform.Platform) *Manager {
+	return &Manager{
+		platform: p,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Resolve returns the path to the correct n98-magerun2 phar for the project in
+// projectDir. The GitHub API is called at most once — on the very first run
+// when no suitable phar is cached yet. Subsequent calls are fully offline.
+func (m *Manager) Resolve(projectDir string) (string, error) {
+	magentoVersion := m.detectMagentoVersion(projectDir)
+	pharDir := filepath.Join(m.platform.MageBoxDir(), "magerun")
+
+	if needsLegacy(magentoVersion) {
+		return m.ensurePhar(legacyVersion)
+	}
+
+	// Use any cached modern phar — no API call needed.
+	if cached := findCachedModernVersion(pharDir); cached != "" {
+		return filepath.Join(pharDir, fmt.Sprintf("n98-magerun2-%s.phar", cached)), nil
+	}
+
+	// First run: fetch latest version from GitHub and download it.
+	version, err := fetchLatestVersion(m.httpClient)
+	if err != nil {
+		return "", fmt.Errorf("could not determine latest n98-magerun2 version: %w", err)
+	}
+
+	return m.ensurePhar(version)
+}
+
+// findCachedModernVersion returns the version string of the newest non-legacy
+// phar found in pharDir, or "" if none exist.
+func findCachedModernVersion(pharDir string) string {
+	entries, err := os.ReadDir(pharDir)
+	if err != nil {
+		return ""
+	}
+	var best string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "n98-magerun2-") || !strings.HasSuffix(name, ".phar") {
+			continue
+		}
+		version := strings.TrimSuffix(strings.TrimPrefix(name, "n98-magerun2-"), ".phar")
+		if version == legacyVersion {
+			continue
+		}
+		if best == "" || compareVersions(version, best) > 0 {
+			best = version
+		}
+	}
+	return best
+}
+
+// compareVersions returns >0 if a is newer than b, 0 if equal, <0 if older.
+func compareVersions(a, b string) int {
+	ap := strings.SplitN(a, ".", 3)
+	bp := strings.SplitN(b, ".", 3)
+	for i := range 3 {
+		x := versionPart(ap, i)
+		y := versionPart(bp, i)
+		if x != y {
+			return x - y
+		}
+	}
+	return 0
+}
+
+func versionPart(parts []string, i int) int {
+	if i >= len(parts) {
+		return 0
+	}
+	n, _ := strconv.Atoi(parts[i])
+	return n
+}
+
+// detectMagentoVersion parses composer.lock in projectDir and returns the
+// installed Magento package version (e.g. "2.4.8"), or "" if not found.
+func (m *Manager) detectMagentoVersion(projectDir string) string {
+	if projectDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(projectDir, "composer.lock"))
+	if err != nil {
+		return ""
+	}
+
+	var lock struct {
+		Packages []struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return ""
+	}
+
+	for _, pkg := range lock.Packages {
+		for _, name := range magentoPackageNames {
+			if pkg.Name == name {
+				return pkg.Version
+			}
+		}
+	}
+	return ""
+}
+
+// ensurePhar returns the path to the cached phar for version, downloading it
+// from GitHub if not already present.
+func (m *Manager) ensurePhar(version string) (string, error) {
+	pharDir := filepath.Join(m.platform.MageBoxDir(), "magerun")
+	if err := os.MkdirAll(pharDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create magerun directory: %w", err)
+	}
+
+	dest := filepath.Join(pharDir, fmt.Sprintf("n98-magerun2-%s.phar", version))
+	if _, err := os.Stat(dest); err == nil {
+		return dest, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Downloading n98-magerun2 v%s...\n", version)
+	url := fmt.Sprintf(pharDownloadBase, version)
+	if err := downloadFile(m.httpClient, url, dest); err != nil {
+		return "", fmt.Errorf("failed to download n98-magerun2 v%s: %w", version, err)
+	}
+	if err := verifyPharChecksum(m.httpClient, dest, version); err != nil {
+		_ = os.Remove(dest)
+		return "", err
+	}
+	if err := os.Chmod(dest, 0755); err != nil {
+		return "", err
+	}
+
+	return dest, nil
+}
+
+// CachedVersion returns the version of the best cached phar
+// ("7.5.0", "9.4.0", etc.), or "" if nothing is cached yet.
+func (m *Manager) CachedVersion() string {
+	pharDir := filepath.Join(m.platform.MageBoxDir(), "magerun")
+	if modern := findCachedModernVersion(pharDir); modern != "" {
+		return modern
+	}
+	legacyPhar := filepath.Join(pharDir, fmt.Sprintf("n98-magerun2-%s.phar", legacyVersion))
+	if _, err := os.Stat(legacyPhar); err == nil {
+		return legacyVersion
+	}
+	return ""
+}
+
+// Install writes the magerun2 wrapper script to ~/.magebox/bin/magerun2.
+func (m *Manager) Install() error {
+	binDir := filepath.Join(m.platform.MageBoxDir(), "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	content, err := lib.GetTemplate(lib.TemplateWrapper, "magerun2.sh")
+	if err != nil {
+		content = magerun2ScriptEmbed
+	}
+
+	dest := filepath.Join(binDir, WrapperName)
+	if err := os.WriteFile(dest, []byte(content), 0755); err != nil {
+		return fmt.Errorf("failed to write magerun2 wrapper: %w", err)
+	}
+	return nil
+}
+
+// IsInstalled reports whether the wrapper script is installed and executable.
+func (m *Manager) IsInstalled() bool {
+	dest := filepath.Join(m.platform.MageBoxDir(), "bin", WrapperName)
+	info, err := os.Stat(dest)
+	if err != nil {
+		return false
+	}
+	return info.Mode().Perm()&0111 != 0
+}

--- a/internal/magerunwrapper/templates/magerun2.sh
+++ b/internal/magerunwrapper/templates/magerun2.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# MageBox magerun2 wrapper
+# Automatically downloads and uses the correct n98-magerun2 version.
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+PHP_WRAPPER="$SCRIPT_DIR/php"
+
+find_project_dir() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.magebox.yaml" ]] || [[ -f "$dir/.magebox.local.yaml" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+project_dir=$(find_project_dir)
+
+resolve_args=()
+if [[ -n "$project_dir" ]]; then
+    resolve_args+=("--project-dir=$project_dir")
+fi
+
+if ! phar_path=$(magebox magerun-resolve "${resolve_args[@]}"); then
+    exit 1
+fi
+
+if [[ -z "$phar_path" ]]; then
+    echo "Error: Could not resolve n98-magerun2. Run 'magebox check' for details." >&2
+    exit 1
+fi
+
+exec "$PHP_WRAPPER" "$phar_path" "$@"

--- a/internal/magerunwrapper/versions.go
+++ b/internal/magerunwrapper/versions.go
@@ -1,0 +1,45 @@
+package magerunwrapper
+
+import (
+	"strconv"
+	"strings"
+)
+
+// magentoPackageNames lists the Composer package names used by Magento distributions.
+var magentoPackageNames = []string{
+	"magento/product-community-edition",
+	"mage-os/mage-os-community-edition",
+	"magento/magento2-community-edition",
+}
+
+const (
+	// legacyVersion is the last n98-magerun2 release compatible with Magento < 2.4.5.
+	legacyVersion = "7.5.0"
+	// legacyMinorCutoff is the first 2.4.x minor that works with the modern magerun2 series.
+	legacyMinorCutoff = 5
+)
+
+// needsLegacy reports whether magentoVersion requires the 7.x magerun2 series.
+// Returns false (use latest) when version is empty or not a 2.4.x string.
+func needsLegacy(magentoVersion string) bool {
+	minor, ok := parseMagentoMinor(magentoVersion)
+	return ok && minor < legacyMinorCutoff
+}
+
+// parseMagentoMinor extracts the patch number from a 2.4.x version string such
+// as "2.4.8" or "2.4.5-p1". Returns (0, false) for any non-2.4.x input.
+func parseMagentoMinor(version string) (int, bool) {
+	version = strings.TrimPrefix(version, "v")
+	if idx := strings.IndexByte(version, '-'); idx >= 0 {
+		version = version[:idx]
+	}
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) != 3 || parts[0] != "2" || parts[1] != "4" {
+		return 0, false
+	}
+	minor, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, false
+	}
+	return minor, true
+}

--- a/internal/magerunwrapper/versions_test.go
+++ b/internal/magerunwrapper/versions_test.go
@@ -1,0 +1,58 @@
+package magerunwrapper
+
+import "testing"
+
+func TestParseMagentoMinor(t *testing.T) {
+	tests := []struct {
+		version string
+		minor   int
+		ok      bool
+	}{
+		{"2.4.0", 0, true},
+		{"2.4.4", 4, true},
+		{"2.4.5", 5, true},
+		{"2.4.8", 8, true},
+		{"2.4.5-p1", 5, true},
+		{"2.4.8-p3", 8, true},
+		{"v2.4.7", 7, true},
+		// non-2.4.x inputs
+		{"2.3.7", 0, false},
+		{"3.0.0", 0, false},
+		{"103.0.8", 0, false}, // magento/framework version
+		{"", 0, false},
+		{"invalid", 0, false},
+	}
+
+	for _, tt := range tests {
+		got, ok := parseMagentoMinor(tt.version)
+		if ok != tt.ok || got != tt.minor {
+			t.Errorf("parseMagentoMinor(%q) = (%d, %v), want (%d, %v)", tt.version, got, ok, tt.minor, tt.ok)
+		}
+	}
+}
+
+func TestNeedsLegacy(t *testing.T) {
+	tests := []struct {
+		version string
+		legacy  bool
+	}{
+		{"2.4.0", true},
+		{"2.4.3", true},
+		{"2.4.4", true},
+		{"2.4.5", false},
+		{"2.4.8", false},
+		{"2.4.4-p1", true},
+		{"2.4.5-p2", false},
+		// unknown/empty — fall back to latest
+		{"", false},
+		{"invalid", false},
+		{"2.3.7", false},
+	}
+
+	for _, tt := range tests {
+		got := needsLegacy(tt.version)
+		if got != tt.legacy {
+			t.Errorf("needsLegacy(%q) = %v, want %v", tt.version, got, tt.legacy)
+		}
+	}
+}

--- a/vitepress/guide/bootstrap.md
+++ b/vitepress/guide/bootstrap.md
@@ -77,9 +77,11 @@ Running `magebox bootstrap` will:
    - **macOS**: Create `/etc/resolver/test` for wildcard resolution
    - Falls back to `/etc/hosts` mode if dnsmasq setup fails
 
-8. **Install PHP Wrapper**
-   - Create smart PHP wrapper at `~/.magebox/bin/php`
-   - Automatic PHP version detection per project
+8. **Install CLI Wrappers**
+   - Create smart PHP wrapper at `~/.magebox/bin/php` — automatic PHP version detection per project
+   - Create Composer wrapper at `~/.magebox/bin/composer` — runs with project PHP version
+   - Create Blackfire wrapper at `~/.magebox/bin/blackfire` — profiles with project PHP version
+   - Create magerun2 wrapper at `~/.magebox/bin/magerun2` — auto-downloads correct n98-magerun2 phar on first use
 
 9. **PHP-FPM Setup (Linux)**
    - Enable and start PHP-FPM services for installed versions

--- a/vitepress/guide/php-wrapper.md
+++ b/vitepress/guide/php-wrapper.md
@@ -1,10 +1,11 @@
 # CLI Wrappers
 
-MageBox includes smart CLI wrappers that automatically use the correct PHP version based on your project configuration. After bootstrap, three wrappers are installed in `~/.magebox/bin/`:
+MageBox includes smart CLI wrappers that automatically use the correct tool versions based on your project configuration. After bootstrap, four wrappers are installed in `~/.magebox/bin/`:
 
 - **php** - Automatically uses project's PHP version
 - **composer** - Runs Composer with project's PHP version
 - **blackfire** - Runs Blackfire profiler with project's PHP version
+- **magerun2** - Automatically downloads and runs the correct n98-magerun2 version
 
 ## Overview
 
@@ -228,6 +229,62 @@ blackfire agent:start
 blackfire --ignore-exit-status run php bin/magento some:command
 ```
 
+## magerun2 Wrapper
+
+The magerun2 wrapper at `~/.magebox/bin/magerun2` automatically manages the correct n98-magerun2 version for your project. No manual installation or version management required.
+
+### How It Works
+
+```bash
+# When you run:
+magerun2 cache:flush
+
+# The wrapper:
+# 1. Walks up from $PWD to find the project directory
+# 2. Reads the Magento version from composer.lock
+# 3. Ensures the correct phar is downloaded (once, then installed)
+# 4. Executes via ~/.magebox/bin/php for correct PHP version
+```
+
+### Version Selection
+
+| Magento version | n98-magerun2 |
+|-----------------|--------------|
+| 2.4.0 – 2.4.4  | 7.5.0 (legacy series) |
+| 2.4.5 and up   | Latest release from GitHub |
+
+The GitHub API is called **at most once** — on first use when no phar is installed yet. After that, invocations are fully offline with zero network overhead.
+
+Phars are stored in `~/.magebox/magerun/` and multiple versions can coexist, so switching between projects with different Magento versions is seamless.
+
+### Usage Examples
+
+```bash
+cd /path/to/project
+
+# All standard magerun2 commands work as-is
+magerun2 cache:flush
+magerun2 setup:upgrade
+magerun2 indexer:reindex
+magerun2 sys:info
+
+# MageBox also forwards unknown commands automatically
+magebox cache:flush   # → magerun2 cache:flush
+```
+
+### Updating magerun2
+
+The wrapper never auto-updates — once a phar is installed it is used permanently. To get a newer version, delete the installed phar and run any `magerun2` command:
+
+```bash
+rm ~/.magebox/magerun/n98-magerun2-*.phar
+magerun2 --version   # downloads latest
+```
+
+::: tip Health Check
+`magebox check` shows the wrapper status and which phar version is installed.
+:::
+
 ## Multiple PHP Versions
 
 The wrappers support all PHP versions installed on your system:
@@ -407,3 +464,4 @@ export PATH=$(echo $PATH | sed "s|$HOME/.magebox/bin:||")
 | PHP | `~/.magebox/bin/php` | Automatic PHP version detection |
 | Composer | `~/.magebox/bin/composer` | Runs Composer with correct PHP |
 | Blackfire | `~/.magebox/bin/blackfire` | Profiles with correct PHP |
+| magerun2 | `~/.magebox/bin/magerun2` | Auto-managed n98-magerun2 phar |

--- a/vitepress/reference/commands.md
+++ b/vitepress/reference/commands.md
@@ -532,9 +532,17 @@ commands:
 
 ---
 
-### Magerun2 Fallback
+### Magerun2
 
-Any command not recognized by MageBox is automatically forwarded to magerun2 (if installed).
+MageBox automatically manages n98-magerun2 — no manual installation required. The correct version is downloaded on first use based on your Magento version, then installed permanently.
+
+```bash
+magerun2 cache:flush
+magerun2 setup:upgrade
+magerun2 sys:info
+```
+
+Any command not recognized by MageBox is also automatically forwarded to magerun2:
 
 ```bash
 magebox cache:flush          # → magerun2 cache:flush
@@ -543,6 +551,15 @@ magebox sys:info             # → magerun2 sys:info
 ```
 
 MageBox verifies the command exists in magerun2 before forwarding. The project's configured PHP version is automatically used. Custom commands defined in `.magebox.yaml` take priority over magerun2 commands.
+
+**Version selection** is based on the Magento version detected from `composer.lock`:
+
+| Magento version | n98-magerun2 |
+|-----------------|--------------|
+| 2.4.0 – 2.4.4  | 7.5.0 |
+| 2.4.5 and up   | Latest |
+
+The phar is installed in `~/.magebox/magerun/` and never re-downloaded automatically. To update: `rm ~/.magebox/magerun/n98-magerun2-*.phar`.
 
 ## Database Commands
 


### PR DESCRIPTION
Closes #85

## Summary

- Installs `~/.magebox/bin/magerun2` wrapper during bootstrap — no manual version management required
- Detects Magento version from `composer.lock` and maps to the correct n98-magerun2 version: 7.5.0 for Magento < 2.4.5, latest GitHub release for 2.4.5+
- GitHub API is called **at most once** — on first use when no phar is installed. All subsequent invocations are fully offline
- SHA256 checksum verification on download (gracefully skipped if not available)
- Integrates with `magebox check` to show wrapper and phar status
- Documentation updated: `php-wrapper.md`, `bootstrap.md`, `commands.md`

## How it works

```
magerun2 cache:flush
  → ~/.magebox/bin/magerun2 (shell wrapper)
    → magebox magerun-resolve [--project-dir=...]
      → detects Magento version from composer.lock
      → returns path to correct phar (downloads once if needed)
    → ~/.magebox/bin/php <phar> cache:flush
```

## Version selection

| Magento version | n98-magerun2 |
|-----------------|--------------|
| 2.4.0 – 2.4.4  | 7.5.0 (legacy series) |
| 2.4.5 and up   | Latest release from GitHub |

## Tested 

Confirmed working for:
- Magento 2.4.3
- Magento 2.4.6
- Magento 2.4.7