### PR TITLE
docs: fill documentation coverage gaps

### DIFF
--- a/vitepress/guide/bootstrap.md
+++ b/vitepress/guide/bootstrap.md
@@ -53,10 +53,9 @@ Running `magebox bootstrap` will:
    - Enable HTTPS for all projects
 
 4. **Port Forwarding (macOS)**
-   - Set up pf (packet filter) rules
-   - Forward port 80 → 8080
-   - Forward port 443 → 8443
-   - Install LaunchDaemon for persistence
+   - Install `magebox _portforward` TCP proxy daemon
+   - Forward port 80 → 8080 and 443 → 8443
+   - Install LaunchDaemon for persistence across reboots
 
 5. **Configure Nginx**
    - Create MageBox vhosts directory
@@ -173,33 +172,29 @@ Then run 'magebox init' in your project directory to get started.
 
 ### Why Port Forwarding?
 
-On macOS, MageBox uses **packet filter (pf)** to enable services to run as your regular user:
+On macOS, MageBox uses a **TCP proxy daemon** to enable services to run as your regular user:
 
 - **Problem**: Web servers need ports 80/443, but only root can bind to ports below 1024
-- **Solution**: Nginx runs on 8080/8443, pf transparently forwards from 80/443
+- **Solution**: Nginx runs on 8080/8443, a lightweight proxy transparently forwards from 80/443
 - **Result**: Access sites at clean URLs like `https://mystore.test` without sudo
 
 ### How It Works
 
 ```
-Browser → Port 443 → pf → Port 8443 → Nginx (your user)
+Browser → Port 443 → magebox _portforward → Port 8443 → Nginx (your user)
 ```
+
+MageBox runs a hidden `magebox _portforward` daemon process that listens on ports 80 and 443 and forwards all traffic to Nginx on 8080/8443. This pure Go TCP proxy requires no kernel pf rules and is far more reliable across reboots and sleep/wake cycles.
 
 ### What Gets Installed
 
-**1. PF Rules File** (`/etc/pf.anchors/com.magebox`):
-```
-rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
-rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
-```
-
-**2. LaunchDaemon** (`/Library/LaunchDaemons/com.magebox.portforward.plist`):
-- Loads pf rules automatically on boot
-- Runs as root (required for pf)
-- Enables forwarding transparently
-- **Sleep/Wake Recovery**: Uses `KeepAlive.NetworkState` to reload rules when network comes up after sleep
-- **Periodic Check**: Verifies rules every 30 seconds as a fallback
+**LaunchDaemon** (`/Library/LaunchDaemons/com.magebox.portforward.plist`):
+- Runs `magebox _portforward` as root (required to bind ports 80/443)
+- `KeepAlive: true` — launchd automatically restarts it if it crashes
+- Survives reboots, sleep/wake, and network changes without manual intervention
 - **Auto-Upgrade**: Running `magebox bootstrap` automatically upgrades old LaunchDaemon versions
+
+If you previously had the pf-based LaunchDaemon installed, bootstrap automatically removes the legacy pf anchor files and upgrades to the TCP proxy daemon.
 
 ### Verification
 
@@ -207,8 +202,8 @@ rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
 # Check if LaunchDaemon exists
 ls -la /Library/LaunchDaemons/com.magebox.portforward.plist
 
-# Check if pf rules exist
-cat /etc/pf.anchors/com.magebox
+# Check if the daemon is loaded
+sudo launchctl list | grep magebox
 
 # Verify it works
 curl -I https://mystore.test
@@ -375,21 +370,21 @@ Services running after bootstrap:
 
 ### Port Forwarding Not Working (macOS)
 
-1. Verify LaunchDaemon is loaded and check version:
+1. Verify LaunchDaemon is loaded:
    ```bash
    sudo launchctl list | grep magebox
-   grep "MageBox-Version" /Library/LaunchDaemons/com.magebox.portforward.plist
    ```
 
-2. Check if rules are active (use `-sn` for NAT/redirect rules):
+2. Check if the proxy daemon is running:
    ```bash
-   sudo pfctl -a com.magebox -sn
-   # Should show: rdr pass on lo0 inet proto tcp ... port = 80 -> 127.0.0.1 port 8080
+   pgrep -a magebox
+   # Should show a magebox _portforward process
    ```
 
-3. Reload anchor rules manually:
+3. Reload the LaunchDaemon manually:
    ```bash
-   sudo pfctl -a com.magebox -f /etc/pf.anchors/com.magebox
+   sudo launchctl unload /Library/LaunchDaemons/com.magebox.portforward.plist
+   sudo launchctl load /Library/LaunchDaemons/com.magebox.portforward.plist
    ```
 
 4. Check nginx is listening:
@@ -398,10 +393,10 @@ Services running after bootstrap:
    lsof -nP -iTCP:8443 -sTCP:LISTEN
    ```
 
-5. **Upgrade LaunchDaemon** (if using old version without sleep/wake support):
+5. **Upgrade LaunchDaemon** (if using old pf-based version):
    ```bash
    magebox bootstrap
-   # This automatically detects and upgrades old LaunchDaemon versions
+   # Automatically removes legacy pf rules and installs the TCP proxy daemon
    ```
 
 ### Docker not running

--- a/vitepress/reference/commands.md
+++ b/vitepress/reference/commands.md
@@ -518,6 +518,7 @@ Execute a custom command.
 ```bash
 magebox run deploy
 magebox run reindex
+magebox run          # Interactive selector when no name given
 ```
 
 Runs commands defined in `.magebox.yaml`:
@@ -527,8 +528,10 @@ commands:
   deploy: "php bin/magento deploy:mode:set production"
 ```
 
+When called without a command name, an interactive TUI menu is shown listing all available custom commands. Use arrow keys to select, Enter to run.
+
 **Options:**
-- `--list` - Show available commands
+- `--list`, `-l` - Print available commands as plain text (no interactive UI)
 
 ---
 
@@ -1031,6 +1034,80 @@ magebox elasticvue status
 ```
 
 Shows whether Elasticvue is enabled, running, and the web UI URL.
+
+## Mailpit Commands
+
+### `magebox mailpit open`
+
+Open the Mailpit email testing UI in the default browser.
+
+```bash
+magebox mailpit open
+```
+
+Reads the actual port from the running container via `docker port`. Falls back to port 8025 if the container is not running.
+
+---
+
+### `magebox mailpit status`
+
+Show Mailpit status and connection details.
+
+```bash
+magebox mailpit status
+```
+
+Displays whether Mailpit is running, the web UI URL, and the SMTP address (`localhost:1025`). Mailpit is always enabled and starts automatically with global services.
+
+::: tip
+See [Mailpit](/services/mailpit) for configuration and usage details.
+:::
+
+## phpMyAdmin Commands
+
+### `magebox phpmyadmin enable`
+
+Enable the phpMyAdmin web UI.
+
+```bash
+magebox phpmyadmin enable
+```
+
+Sets `phpmyadmin: true` in the global config, starts the container, and prints the URL (default port 8036). Uses arbitrary server mode — connect to any database container by name (e.g. `magebox-mysql-8.0`).
+
+---
+
+### `magebox phpmyadmin disable`
+
+Disable phpMyAdmin.
+
+```bash
+magebox phpmyadmin disable
+```
+
+Stops and removes the container, sets `phpmyadmin: false` in global config.
+
+---
+
+### `magebox phpmyadmin status`
+
+Show phpMyAdmin status.
+
+```bash
+magebox phpmyadmin status
+```
+
+---
+
+### `magebox phpmyadmin open`
+
+Open phpMyAdmin in the default browser.
+
+```bash
+magebox phpmyadmin open
+```
+
+Reads the actual port from the running container. Errors if phpMyAdmin is not running.
 
 ## Expose Commands
 
@@ -1882,6 +1959,189 @@ magebox sync --media
 Run from within a project directory. Auto-detects team from git remote.
 :::
 
+## Server Commands
+
+Commands for managing the MageBox team server process on the machine where it is hosted. These are server-side commands, not client commands.
+
+### `magebox server init`
+
+Initialize the team server configuration.
+
+```bash
+magebox server init
+```
+
+Generates the master key, admin token, SSH CA key pair, and initial configuration. Run this once on the machine that will host the team server.
+
+---
+
+### `magebox server start`
+
+Start the team server.
+
+```bash
+magebox server start
+```
+
+---
+
+### `magebox server stop`
+
+Stop the team server.
+
+```bash
+magebox server stop
+```
+
+---
+
+### `magebox server status`
+
+Check team server status.
+
+```bash
+magebox server status
+```
+
+::: tip
+See the [Team Server](/guide/team-server) guide for full setup and administration details.
+:::
+
+## Environment Commands
+
+Manage remote SSH environments. Environments are stored globally and can be used to quickly SSH into remote servers.
+
+### `magebox env`
+
+List all configured remote environments.
+
+```bash
+magebox env
+```
+
+---
+
+### `magebox env add <name>`
+
+Add a new remote environment.
+
+```bash
+magebox env add staging --user deploy --host staging.example.com
+magebox env add production --user deploy --host prod.example.com --port 2222
+magebox env add cloud --user magento --host 10.0.0.1 --key ~/.ssh/cloud_key
+magebox env add tunnel --ssh-command "ssh -J jump@bastion.example.com deploy@internal.example.com"
+```
+
+**Options:**
+- `--user`, `-u` - SSH username (required for standard connections)
+- `--host`, `-H` - SSH host or IP (required for standard connections)
+- `--port`, `-p` - SSH port (default: 22)
+- `--key`, `-k` - Path to SSH private key
+- `--ssh-command` - Full custom SSH command (for jump hosts/tunnels, overrides user/host/port)
+
+---
+
+### `magebox env remove <name>`
+
+Remove a remote environment. Aliases: `rm`, `delete`.
+
+```bash
+magebox env remove staging
+```
+
+---
+
+### `magebox env ssh <name>`
+
+SSH into a configured remote environment.
+
+```bash
+magebox env ssh staging
+magebox env ssh production
+```
+
+---
+
+### `magebox env show <name>`
+
+Show connection details for an environment.
+
+```bash
+magebox env show staging
+```
+
+---
+
+### `magebox env sync`
+
+Sync the list of accessible environments from the team server.
+
+```bash
+magebox env sync
+```
+
+Fetches environments you have access to from the connected team server and updates the local cache. Run this after your access has been updated on the server.
+
+## SSH Commands
+
+### `magebox ssh <environment>`
+
+SSH into a team server environment using your SSH certificate.
+
+```bash
+magebox ssh myproject/staging
+magebox ssh myproject/production
+```
+
+Environments are in the format `project/environment`. Uses the SSH key generated when joining the team server. If a certificate is configured, it is used automatically. Warns if the certificate is expired or missing.
+
+```bash
+# Renew certificate if prompted
+magebox cert renew
+```
+
+## Certificate Commands
+
+Commands for managing SSH certificates issued by the team server CA.
+
+### `magebox cert renew`
+
+Renew your SSH certificate from the team server.
+
+```bash
+magebox cert renew
+magebox cert renew --quiet   # Suppress output (for cron/scripts)
+```
+
+Certificates are valid for 24 hours. The renewed certificate is saved to `~/.magebox/keys/<server>-cert.pub`.
+
+**Options:**
+- `--quiet` - Suppress output
+
+---
+
+### `magebox cert show`
+
+Show information about your current SSH certificate.
+
+```bash
+magebox cert show
+```
+
+Displays the certificate file path, size, modification time, and type. Run `ssh-keygen -L -f <cert-file>` for full certificate details.
+
+---
+
+### `magebox cert expiry`
+
+Check when your SSH certificate expires.
+
+```bash
+magebox cert expiry
+```
+
+Shows whether the certificate is valid, when it expires, and how much time remains.
+
 ## Test Commands
 
 Commands for running tests and code quality checks.
@@ -2044,6 +2304,46 @@ sandbox:
 ```
 
 ---
+
+## Service Commands
+
+Commands for managing the MageBox autostart service, which starts global Docker services and all projects automatically at login.
+
+### `magebox service install`
+
+Install the MageBox autostart service.
+
+```bash
+magebox service install
+```
+
+On **macOS**: installs a LaunchAgent (`~/Library/LaunchAgents/com.qoliber.magebox.plist`) that runs `magebox global start` at login.
+
+On **Linux**: installs a systemd user service (`~/.config/systemd/user/magebox.service`) and enables it with `systemctl --user enable`.
+
+After installation, all global services and running projects start automatically when you log in — no manual `magebox global start` needed.
+
+---
+
+### `magebox service uninstall`
+
+Remove the MageBox autostart service.
+
+```bash
+magebox service uninstall
+```
+
+Unloads and removes the LaunchAgent (macOS) or disables and removes the systemd unit (Linux).
+
+---
+
+### `magebox service status`
+
+Show whether the autostart service is installed and active.
+
+```bash
+magebox service status
+```
 
 ## Utility Commands
 

--- a/vitepress/reference/config-options.md
+++ b/vitepress/reference/config-options.md
@@ -16,6 +16,24 @@ name: mystore
 
 ---
 
+### type
+
+`string` | Default: `"magento"`
+
+Project type. Controls default document root detection and Magento-specific behaviour.
+
+```yaml
+type: magento   # default
+type: laravel   # Laravel project
+```
+
+| Value | Document root default | Notes |
+|-------|----------------------|-------|
+| `magento` | `pub` | Enables Magento-specific commands |
+| `laravel` | `public` | Skips Magento-specific setup steps |
+
+---
+
 ### domains
 
 **Required** | `array`
@@ -54,6 +72,22 @@ php: "8.2"
 ```
 
 **Supported values:** `"8.1"`, `"8.2"`, `"8.3"`, `"8.4"`
+
+---
+
+### isolated
+
+`boolean` | Default: `false`
+
+Run this project's PHP-FPM in a dedicated master process, isolated from other projects using the same PHP version.
+
+```yaml
+isolated: true
+```
+
+Useful when you need per-project PHP system settings (`opcache.preload`, `opcache.jit`, etc.) that can only be set in `php.ini` and would otherwise affect all projects on the same PHP version.
+
+See [`magebox php isolate`](/reference/commands#magebox-php-isolate) for more details.
 
 ---
 
@@ -148,6 +182,26 @@ env:
 
 ---
 
+### php_ini
+
+`object`
+
+Per-project PHP INI overrides. Values are injected into the PHP-FPM pool as `php_admin_value` directives, so they apply only to this project's pool and override any global `php.ini` settings.
+
+```yaml
+php_ini:
+  memory_limit: 1G
+  max_execution_time: 300
+  tideways.api_key: abc123       # Per-project Tideways API key
+  xdebug.mode: debug,develop
+```
+
+::: tip
+Most settings can also be managed through `magebox php ini set <key> <value>`, which writes to this section automatically.
+:::
+
+---
+
 ### commands
 
 `object`
@@ -173,6 +227,63 @@ commands:
 |----------|------|-------------|
 | `description` | string | Help text for the command |
 | `run` | string | Command(s) to execute |
+
+---
+
+### testing
+
+`object`
+
+Testing tool configuration. Used by `magebox test` commands.
+
+```yaml
+testing:
+  phpunit:
+    config: dev/tests/unit/phpunit.xml
+  phpstan:
+    level: 5
+    paths:
+      - app/code/Vendor/Module
+  phpcs:
+    standard: Magento2
+    paths:
+      - app/code/Vendor/Module
+  phpmd:
+    ruleset: cleancode,design
+    paths:
+      - app/code/Vendor/Module
+```
+
+::: tip
+Run `magebox test setup` to configure this section interactively.
+:::
+
+---
+
+### sandbox
+
+`object`
+
+Bubblewrap sandbox configuration for AI coding agents (`magebox sandbox`). Controls which filesystem paths are accessible inside the sandbox.
+
+```yaml
+sandbox:
+  tool_profiles:
+    claude:
+      extra_binds:
+        - /path/to/extra/dir
+    codex:
+      extra_binds: []
+```
+
+#### Sandbox Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `tool_profiles` | object | Per-tool overrides keyed by tool name (`claude`, `codex`) |
+| `tool_profiles.<tool>.extra_binds` | array | Extra read-write bind mounts added to the sandbox |
+
+See [`magebox sandbox`](/reference/commands#magebox-sandbox-tool----tool-args) for details on what is accessible by default.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Fix outdated port forwarding docs** — `bootstrap.md` still described the old `pf`/`pfctl` approach; updated to reflect the current TCP proxy daemon (`magebox _portforward`) introduced in #98
- **Add missing commands to `commands.md`**: `mailpit`, `phpmyadmin`, `service`, `server`, `env`, `ssh`, `cert`
- **Document `magebox run` interactive TUI** — running without arguments shows a picker; `--list` flag documented
- **Add missing project config options to `config-options.md`**: `type`, `isolated`, `php_ini`, `testing`, `sandbox`