### PR TITLE
Scope OpenSearch/Elasticsearch index prefix to project name

### DIFF
--- a/cmd/magebox/new.go
+++ b/cmd/magebox/new.go
@@ -812,16 +812,16 @@ commands:
     --search-engine=opensearch \
     --opensearch-host=127.0.0.1 \
     --opensearch-port=%d \
-    --opensearch-index-prefix=magento2 \
-    --opensearch-timeout=15`, searchPort)
+    --opensearch-index-prefix=%s \
+    --opensearch-timeout=15`, searchPort, projectName)
 	} else if searchEngine == "elasticsearch" {
 		searchPort := docker.GetElasticsearchPort(searchVersion)
 		installCmd += fmt.Sprintf(` \
     --search-engine=elasticsearch7 \
     --elasticsearch-host=127.0.0.1 \
     --elasticsearch-port=%d \
-    --elasticsearch-index-prefix=magento2 \
-    --elasticsearch-timeout=15`, searchPort)
+    --elasticsearch-index-prefix=%s \
+    --elasticsearch-timeout=15`, searchPort, projectName)
 	}
 
 	// Add cache config (Valkey is Redis-compatible, same Magento flags)
@@ -1174,7 +1174,7 @@ commands:
 		"--search-engine=opensearch",
 		"--opensearch-host=127.0.0.1",
 		fmt.Sprintf("--opensearch-port=%d", opensearchPort),
-		"--opensearch-index-prefix=magento2",
+		"--opensearch-index-prefix=" + projectName,
 		"--opensearch-timeout=15",
 	}
 

--- a/vitepress/guide/quick-start.md
+++ b/vitepress/guide/quick-start.md
@@ -35,7 +35,7 @@ php bin/magento setup:install \
     --search-engine=opensearch \
     --opensearch-host=127.0.0.1 \
     --opensearch-port=9200 \
-    --opensearch-index-prefix=magento2 \
+    --opensearch-index-prefix=mystore \
     --session-save=redis \
     --session-save-redis-host=127.0.0.1 \
     --session-save-redis-port=6379 \

--- a/vitepress/guide/search.md
+++ b/vitepress/guide/search.md
@@ -71,6 +71,10 @@ services:
 
 ## Magento Configuration
 
+::: warning Use your project name as index prefix
+MageBox projects share a single OpenSearch/Elasticsearch Docker instance on port 9200. Using the same prefix (e.g. `magento2`) across projects causes index collisions — one project's reindex will overwrite another's data. Always set the prefix to your project name.
+:::
+
 ### OpenSearch
 
 Via CLI:
@@ -79,7 +83,7 @@ Via CLI:
 php bin/magento config:set catalog/search/engine opensearch
 php bin/magento config:set catalog/search/opensearch_server_hostname 127.0.0.1
 php bin/magento config:set catalog/search/opensearch_server_port 9200
-php bin/magento config:set catalog/search/opensearch_index_prefix magento2
+php bin/magento config:set catalog/search/opensearch_index_prefix myproject
 ```
 
 Or in `app/etc/env.php`:
@@ -92,7 +96,7 @@ Or in `app/etc/env.php`:
                 'engine' => 'opensearch',
                 'opensearch_server_hostname' => '127.0.0.1',
                 'opensearch_server_port' => '9200',
-                'opensearch_index_prefix' => 'magento2',
+                'opensearch_index_prefix' => 'myproject',
                 'opensearch_enable_auth' => '0',
                 'opensearch_server_timeout' => '15'
             ]
@@ -111,7 +115,7 @@ Or in `app/etc/env.php`:
                 'engine' => 'elasticsearch7',
                 'elasticsearch7_server_hostname' => '127.0.0.1',
                 'elasticsearch7_server_port' => '9200',
-                'elasticsearch7_index_prefix' => 'magento2',
+                'elasticsearch7_index_prefix' => 'myproject',
                 'elasticsearch7_enable_auth' => '0',
                 'elasticsearch7_server_timeout' => '15'
             ]
@@ -130,7 +134,7 @@ Or in `app/etc/env.php`:
                 'engine' => 'elasticsearch8',
                 'elasticsearch8_server_hostname' => '127.0.0.1',
                 'elasticsearch8_server_port' => '9200',
-                'elasticsearch8_index_prefix' => 'magento2',
+                'elasticsearch8_index_prefix' => 'myproject',
                 'elasticsearch8_enable_auth' => '0',
                 'elasticsearch8_server_timeout' => '15'
             ]

--- a/vitepress/services/opensearch.md
+++ b/vitepress/services/opensearch.md
@@ -85,12 +85,16 @@ These plugins enable:
 
 ### Via Install Command
 
+::: warning Use your project name as index prefix
+MageBox projects share a single OpenSearch/Elasticsearch Docker instance on port 9200. Using the same prefix (e.g. `magento2`) across projects causes index collisions — one project's reindex will overwrite another's data. Always set the prefix to your project name.
+:::
+
 ```bash
 php bin/magento setup:install \
     --search-engine=opensearch \
     --opensearch-host=127.0.0.1 \
     --opensearch-port=9200 \
-    --opensearch-index-prefix=magento2 \
+    --opensearch-index-prefix=myproject \
     --opensearch-timeout=15 \
     # ... other options
 ```
@@ -102,7 +106,7 @@ php bin/magento setup:install \
     --search-engine=elasticsearch8 \
     --elasticsearch-host=127.0.0.1 \
     --elasticsearch-port=9200 \
-    --elasticsearch-index-prefix=magento2 \
+    --elasticsearch-index-prefix=myproject \
     --elasticsearch-timeout=15 \
     # ... other options
 ```
@@ -125,7 +129,7 @@ php bin/magento setup:install \
                 'engine' => 'opensearch',
                 'opensearch_server_hostname' => '127.0.0.1',
                 'opensearch_server_port' => '9200',
-                'opensearch_index_prefix' => 'magento2',
+                'opensearch_index_prefix' => 'myproject',
                 'opensearch_server_timeout' => '15'
             ]
         ]
@@ -159,7 +163,7 @@ php bin/magento indexer:reindex catalogsearch_fulltext
 
 ```bash
 # Delete all Magento indices
-curl -X DELETE http://127.0.0.1:9200/magento2_*
+curl -X DELETE http://127.0.0.1:9200/myproject_*
 
 # Reindex
 php bin/magento indexer:reindex catalogsearch_fulltext
@@ -265,7 +269,7 @@ If status is "red":
 
 ```bash
 # Delete all indices and reindex
-curl -X DELETE http://127.0.0.1:9200/magento2_*
+curl -X DELETE http://127.0.0.1:9200/myproject_*
 php bin/magento indexer:reindex catalogsearch_fulltext
 ```
 
@@ -388,7 +392,7 @@ After large catalog imports:
 
 ```bash
 # Force merge (reduces segment count)
-curl -X POST "http://127.0.0.1:9200/magento2_*/_forcemerge?max_num_segments=1"
+curl -X POST "http://127.0.0.1:9200/myproject_*/_forcemerge?max_num_segments=1"
 ```
 
 ### Query Debugging
@@ -405,7 +409,7 @@ Then check `var/log/debug.log` for search queries.
 
 ```bash
 # Watch indexing in real-time
-watch -n 1 'curl -s http://127.0.0.1:9200/_cat/indices?v | grep magento'
+watch -n 1 'curl -s http://127.0.0.1:9200/_cat/indices?v | grep myproject'
 
 # Check pending tasks
 curl http://127.0.0.1:9200/_cluster/pending_tasks?pretty


### PR DESCRIPTION
## Problem

Multiple MageBox projects share a single OpenSearch/Elasticsearch Docker instance (port 9200). The docs and `magebox new` were hardcoding `magento2` as the index prefix everywhere. When two projects use the same prefix, a reindex on one project overwrites the indices of the other.

## Changes

### `cmd/magebox/new.go`

- **Interactive wizard**: the displayed `setup:install` command now uses the project name as `--opensearch-index-prefix` / `--elasticsearch-index-prefix`
- **Quick install** (`--quick` flag): the actual `setup:install` execution now passes the project name as the index prefix

### Docs

- `vitepress/services/opensearch.md` — replaced `magento2` with `myproject` in all prefix examples; added `:::warning` callout explaining the shared-instance problem
- `vitepress/guide/search.md` — same warning callout + replaced `magento2` with `myproject` in all Magento configuration examples
- `vitepress/guide/quick-start.md` — replaced `--opensearch-index-prefix=magento2` with `mystore` (matching the example project name used throughout that page)