### PR TITLE
Ensure installation directory exists before installation

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -145,9 +145,6 @@ install_binary() {
     local install_path="${INSTALL_DIR}/${BINARY_NAME}"
 
     info "Installing to ${install_path}..."
-
-    # Define the target directory
-    INSTALL_DIR="/usr/local/bin"
     
     # Check if the target is the standard /usr/local/bin AND it doesn't exist
     if [ "$INSTALL_DIR" = "/usr/local/bin" ] && [ ! -d "$INSTALL_DIR" ]; then

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -146,6 +146,20 @@ install_binary() {
 
     info "Installing to ${install_path}..."
 
+    # Define the target directory
+    INSTALL_DIR="/usr/local/bin"
+    
+    # Check if the target is the standard /usr/local/bin AND it doesn't exist
+    if [ "$INSTALL_DIR" = "/usr/local/bin" ] && [ ! -d "$INSTALL_DIR" ]; then
+        echo "Default directory $INSTALL_DIR does not exist. Creating it..."
+        if sudo mkdir -p -m 775 "$INSTALL_DIR"; then
+            echo "Successfully created $INSTALL_DIR"
+        else
+            echo "Error: Failed to create $INSTALL_DIR. Please create it manually."
+            exit 1
+        fi
+    fi
+
     # Check if we need sudo
     if [ -w "$INSTALL_DIR" ]; then
         mv "$tmp_file" "$install_path"


### PR DESCRIPTION
Added checks to create the installation directory if it does not exist.

When I first tried to install it failed and wasn't immediately obvious why. 

<img width="884" height="353" alt="Screenshot 2026-05-09 at 08 41 33" src="https://github.com/user-attachments/assets/9021ef2c-53c8-4e6c-b05b-74ca6ca79ce4" />


It will now create the default location and install successfully
<img width="741" height="338" alt="Screenshot 2026-05-09 at 08 42 43" src="https://github.com/user-attachments/assets/5952f7cf-8b7a-46c9-8cdf-bb8fc27f1413" />

