### PR TITLE
Make the PHP-FPM process manager configurable

### DIFF
--- a/cmd/magebox/php_isolate.go
+++ b/cmd/magebox/php_isolate.go
@@ -123,8 +123,19 @@ func runPhpIsolateEnable(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Enabling isolation for %s (PHP %s)...\n", cli.Highlight(cfg.Name), cfg.PHP)
 	fmt.Println()
 
+	// Resolve process manager settings (project `pm` over global `default_pm`)
+	var globalPM *config.PMConfig
+	if globalCfg, gErr := config.LoadGlobalConfig(p.HomeDir); gErr == nil && globalCfg != nil {
+		globalPM = globalCfg.DefaultPM
+	}
+	pmSettings, err := config.ResolvePM(globalPM, cfg.PM)
+	if err != nil {
+		cli.PrintError("Invalid PHP-FPM process manager config: %v", err)
+		return nil
+	}
+
 	// Enable isolation
-	isolatedProject, err := controller.Enable(cfg.Name, cwd, cfg.PHP, settings)
+	isolatedProject, err := controller.Enable(cfg.Name, cwd, cfg.PHP, settings, &pmSettings)
 	if err != nil {
 		cli.PrintError("Failed to enable isolation: %v", err)
 		return nil

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -22,6 +22,12 @@ type GlobalConfig struct {
 	// DefaultServices are the default services for new projects
 	DefaultServices DefaultServices `yaml:"default_services,omitempty"`
 
+	// DefaultPM is the machine-wide PHP-FPM process manager baseline, applied
+	// to every project that does not set its own `pm` block. Useful when many
+	// projects share one machine and the per-pool defaults would collectively
+	// oversubscribe it.
+	DefaultPM *PMConfig `yaml:"default_pm,omitempty"`
+
 	// Portainer enables/disables Portainer Docker UI
 	Portainer bool `yaml:"portainer,omitempty"`
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -196,6 +196,9 @@ func (l *Loader) merge(main, local *Config) *Config {
 	if local.Isolated {
 		result.Isolated = local.Isolated
 	}
+	// Merge process manager settings field by field so a local override can
+	// tune a single value without restating the whole block.
+	result.PM = mergePM(main.PM, local.PM)
 	if local.Testing != nil {
 		result.Testing = local.Testing
 	}

--- a/internal/config/pm.go
+++ b/internal/config/pm.go
@@ -1,0 +1,249 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Process manager modes supported by PHP-FPM.
+const (
+	PMModeStatic   = "static"
+	PMModeDynamic  = "dynamic"
+	PMModeOnDemand = "ondemand"
+)
+
+// Built-in process manager defaults. These match the values MageBox used
+// before `pm` became configurable, so an absent `pm` block keeps the
+// previous behavior.
+const (
+	DefaultPMMode               = PMModeDynamic
+	DefaultPMMaxChildren        = 50
+	DefaultPMStartServers       = 8
+	DefaultPMMinSpareServers    = 4
+	DefaultPMMaxSpareServers    = 12
+	DefaultPMMaxRequests        = 1000
+	DefaultPMProcessIdleTimeout = "10s"
+)
+
+// pmDurationPattern matches PHP-FPM duration values: a positive integer with
+// an optional s/m/h/d suffix (a bare number means seconds).
+var pmDurationPattern = regexp.MustCompile(`^[0-9]+[smhd]?$`)
+
+// PMConfig configures the PHP-FPM process manager for a project's pool.
+//
+// Numeric fields are pointers so that "not set" is distinguishable from an
+// explicit 0, which matters when layering project config over global
+// defaults. Use Resolve to collapse the layers into concrete values.
+type PMConfig struct {
+	// Mode is the PHP-FPM process manager: "static", "dynamic" or "ondemand".
+	Mode string `yaml:"mode,omitempty"`
+
+	// MaxChildren is the maximum number of worker processes. Applies to all modes.
+	MaxChildren *int `yaml:"max_children,omitempty"`
+
+	// StartServers is the number of workers created on startup (dynamic only).
+	StartServers *int `yaml:"start_servers,omitempty"`
+
+	// MinSpareServers is the minimum number of idle workers (dynamic only).
+	MinSpareServers *int `yaml:"min_spare_servers,omitempty"`
+
+	// MaxSpareServers is the maximum number of idle workers (dynamic only).
+	MaxSpareServers *int `yaml:"max_spare_servers,omitempty"`
+
+	// MaxRequests is the number of requests a worker handles before respawning.
+	// 0 disables respawning. Applies to all modes.
+	MaxRequests *int `yaml:"max_requests,omitempty"`
+
+	// ProcessIdleTimeout is how long an idle worker lives before being killed
+	// (ondemand only). Accepts PHP-FPM duration syntax, e.g. "10s", "1m".
+	ProcessIdleTimeout string `yaml:"process_idle_timeout,omitempty"`
+}
+
+// ResolvedPM holds concrete process manager values ready to render into a pool
+// config. Every field is populated; there are no "unset" values.
+type ResolvedPM struct {
+	Mode               string
+	MaxChildren        int
+	StartServers       int
+	MinSpareServers    int
+	MaxSpareServers    int
+	MaxRequests        int
+	ProcessIdleTimeout string
+}
+
+// DefaultResolvedPM returns the built-in process manager settings, used when a
+// project and the global config both leave `pm` unset.
+func DefaultResolvedPM() ResolvedPM {
+	return ResolvedPM{
+		Mode:               DefaultPMMode,
+		MaxChildren:        DefaultPMMaxChildren,
+		StartServers:       DefaultPMStartServers,
+		MinSpareServers:    DefaultPMMinSpareServers,
+		MaxSpareServers:    DefaultPMMaxSpareServers,
+		MaxRequests:        DefaultPMMaxRequests,
+		ProcessIdleTimeout: DefaultPMProcessIdleTimeout,
+	}
+}
+
+// IsDynamic reports whether the resolved mode uses the dynamic process manager.
+func (r ResolvedPM) IsDynamic() bool { return r.Mode == PMModeDynamic }
+
+// IsOnDemand reports whether the resolved mode uses the ondemand process manager.
+func (r ResolvedPM) IsOnDemand() bool { return r.Mode == PMModeOnDemand }
+
+// mergePM layers an override PMConfig on top of a base, field by field. Fields
+// left unset in the override keep the base value. Either argument may be nil.
+func mergePM(base, override *PMConfig) *PMConfig {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	result := PMConfig{}
+	if base != nil {
+		result = *base
+	}
+	if override == nil {
+		return &result
+	}
+
+	if override.Mode != "" {
+		result.Mode = override.Mode
+	}
+	if override.MaxChildren != nil {
+		result.MaxChildren = override.MaxChildren
+	}
+	if override.StartServers != nil {
+		result.StartServers = override.StartServers
+	}
+	if override.MinSpareServers != nil {
+		result.MinSpareServers = override.MinSpareServers
+	}
+	if override.MaxSpareServers != nil {
+		result.MaxSpareServers = override.MaxSpareServers
+	}
+	if override.MaxRequests != nil {
+		result.MaxRequests = override.MaxRequests
+	}
+	if override.ProcessIdleTimeout != "" {
+		result.ProcessIdleTimeout = override.ProcessIdleTimeout
+	}
+
+	return &result
+}
+
+// ResolvePM collapses the global default and project-level process manager
+// settings into concrete values, filling gaps with the built-in defaults.
+// Precedence is project > global > built-in. Both arguments may be nil.
+//
+// The result is validated; an invalid configuration is returned as an error
+// rather than written to a pool file, because PHP-FPM refuses to start the
+// entire master process when a single pool is malformed.
+func ResolvePM(global, project *PMConfig) (ResolvedPM, error) {
+	merged := mergePM(global, project)
+	resolved := DefaultResolvedPM()
+
+	if merged == nil {
+		return resolved, nil
+	}
+
+	if merged.Mode != "" {
+		resolved.Mode = strings.ToLower(strings.TrimSpace(merged.Mode))
+	}
+	if merged.MaxChildren != nil {
+		resolved.MaxChildren = *merged.MaxChildren
+	}
+	if merged.StartServers != nil {
+		resolved.StartServers = *merged.StartServers
+	}
+	if merged.MinSpareServers != nil {
+		resolved.MinSpareServers = *merged.MinSpareServers
+	}
+	if merged.MaxSpareServers != nil {
+		resolved.MaxSpareServers = *merged.MaxSpareServers
+	}
+	if merged.MaxRequests != nil {
+		resolved.MaxRequests = *merged.MaxRequests
+	}
+	if merged.ProcessIdleTimeout != "" {
+		resolved.ProcessIdleTimeout = strings.TrimSpace(merged.ProcessIdleTimeout)
+	}
+
+	// When only max_children is lowered, the dynamic spare-server defaults can
+	// exceed it and PHP-FPM would refuse to start. Scale the untouched spare
+	// values down to fit rather than making the user restate all four.
+	if resolved.IsDynamic() && resolved.MaxChildren > 0 {
+		if merged.MaxSpareServers == nil && resolved.MaxSpareServers > resolved.MaxChildren {
+			resolved.MaxSpareServers = resolved.MaxChildren
+		}
+		if merged.MinSpareServers == nil && resolved.MinSpareServers > resolved.MaxSpareServers {
+			resolved.MinSpareServers = resolved.MaxSpareServers
+		}
+		if merged.StartServers == nil {
+			if resolved.StartServers > resolved.MaxSpareServers {
+				resolved.StartServers = resolved.MaxSpareServers
+			}
+			if resolved.StartServers < resolved.MinSpareServers {
+				resolved.StartServers = resolved.MinSpareServers
+			}
+		}
+	}
+
+	if err := resolved.Validate(); err != nil {
+		return ResolvedPM{}, err
+	}
+
+	return resolved, nil
+}
+
+// Validate checks the resolved settings against the constraints PHP-FPM
+// enforces at startup. It mirrors those rules so misconfiguration surfaces as
+// a MageBox error instead of a failed FPM master that takes down every project
+// sharing the same PHP version.
+func (r ResolvedPM) Validate() error {
+	switch r.Mode {
+	case PMModeStatic, PMModeDynamic, PMModeOnDemand:
+	default:
+		return fmt.Errorf("pm.mode %q is invalid: must be %q, %q or %q",
+			r.Mode, PMModeStatic, PMModeDynamic, PMModeOnDemand)
+	}
+
+	if r.MaxChildren < 1 {
+		return fmt.Errorf("pm.max_children must be at least 1, got %d", r.MaxChildren)
+	}
+
+	if r.MaxRequests < 0 {
+		return fmt.Errorf("pm.max_requests cannot be negative, got %d", r.MaxRequests)
+	}
+
+	if r.IsOnDemand() && !pmDurationPattern.MatchString(r.ProcessIdleTimeout) {
+		return fmt.Errorf("pm.process_idle_timeout %q is invalid: expected a number with an optional s/m/h/d suffix, e.g. \"10s\"",
+			r.ProcessIdleTimeout)
+	}
+
+	if !r.IsDynamic() {
+		return nil
+	}
+
+	if r.StartServers < 1 {
+		return fmt.Errorf("pm.start_servers must be at least 1 when pm.mode is %q, got %d", PMModeDynamic, r.StartServers)
+	}
+	if r.MinSpareServers < 1 {
+		return fmt.Errorf("pm.min_spare_servers must be at least 1 when pm.mode is %q, got %d", PMModeDynamic, r.MinSpareServers)
+	}
+	if r.MaxSpareServers < 1 {
+		return fmt.Errorf("pm.max_spare_servers must be at least 1 when pm.mode is %q, got %d", PMModeDynamic, r.MaxSpareServers)
+	}
+	if r.MinSpareServers > r.MaxSpareServers {
+		return fmt.Errorf("pm.min_spare_servers (%d) cannot exceed pm.max_spare_servers (%d)", r.MinSpareServers, r.MaxSpareServers)
+	}
+	if r.MaxSpareServers > r.MaxChildren {
+		return fmt.Errorf("pm.max_spare_servers (%d) cannot exceed pm.max_children (%d)", r.MaxSpareServers, r.MaxChildren)
+	}
+	if r.StartServers < r.MinSpareServers || r.StartServers > r.MaxSpareServers {
+		return fmt.Errorf("pm.start_servers (%d) must be between pm.min_spare_servers (%d) and pm.max_spare_servers (%d)",
+			r.StartServers, r.MinSpareServers, r.MaxSpareServers)
+	}
+
+	return nil
+}

--- a/internal/config/pm_test.go
+++ b/internal/config/pm_test.go
@@ -1,0 +1,186 @@
+package config
+
+import "testing"
+
+func intPtr(i int) *int { return &i }
+
+func TestResolvePM_DefaultsWhenUnset(t *testing.T) {
+	got, err := ResolvePM(nil, nil)
+	if err != nil {
+		t.Fatalf("ResolvePM(nil, nil) returned error: %v", err)
+	}
+
+	want := DefaultResolvedPM()
+	if got != want {
+		t.Errorf("ResolvePM(nil, nil) = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolvePM_ProjectOverridesGlobal(t *testing.T) {
+	global := &PMConfig{Mode: PMModeOnDemand, MaxChildren: intPtr(20)}
+	project := &PMConfig{MaxChildren: intPtr(8)}
+
+	got, err := ResolvePM(global, project)
+	if err != nil {
+		t.Fatalf("ResolvePM returned error: %v", err)
+	}
+
+	// max_children comes from the project, mode falls through from global.
+	if got.MaxChildren != 8 {
+		t.Errorf("MaxChildren = %d, want 8", got.MaxChildren)
+	}
+	if got.Mode != PMModeOnDemand {
+		t.Errorf("Mode = %q, want %q", got.Mode, PMModeOnDemand)
+	}
+}
+
+func TestResolvePM_GlobalAppliesWhenProjectUnset(t *testing.T) {
+	global := &PMConfig{Mode: PMModeStatic, MaxChildren: intPtr(4), MaxRequests: intPtr(200)}
+
+	got, err := ResolvePM(global, nil)
+	if err != nil {
+		t.Fatalf("ResolvePM returned error: %v", err)
+	}
+
+	if got.Mode != PMModeStatic {
+		t.Errorf("Mode = %q, want %q", got.Mode, PMModeStatic)
+	}
+	if got.MaxChildren != 4 {
+		t.Errorf("MaxChildren = %d, want 4", got.MaxChildren)
+	}
+	if got.MaxRequests != 200 {
+		t.Errorf("MaxRequests = %d, want 200", got.MaxRequests)
+	}
+}
+
+// Lowering only max_children must not produce a config PHP-FPM rejects: the
+// untouched spare-server defaults (4/12, start 8) would exceed it.
+func TestResolvePM_ScalesDynamicDefaultsToFitMaxChildren(t *testing.T) {
+	got, err := ResolvePM(nil, &PMConfig{MaxChildren: intPtr(6)})
+	if err != nil {
+		t.Fatalf("ResolvePM returned error: %v", err)
+	}
+
+	if got.MaxSpareServers > got.MaxChildren {
+		t.Errorf("MaxSpareServers = %d, must not exceed MaxChildren = %d", got.MaxSpareServers, got.MaxChildren)
+	}
+	if got.StartServers > got.MaxSpareServers || got.StartServers < got.MinSpareServers {
+		t.Errorf("StartServers = %d, want within [%d, %d]", got.StartServers, got.MinSpareServers, got.MaxSpareServers)
+	}
+	if err := got.Validate(); err != nil {
+		t.Errorf("scaled result should be valid, got: %v", err)
+	}
+}
+
+// Explicit values are never silently rewritten; a contradictory combination is
+// reported instead.
+func TestResolvePM_ExplicitValuesAreNotScaled(t *testing.T) {
+	_, err := ResolvePM(nil, &PMConfig{
+		MaxChildren:     intPtr(4),
+		MaxSpareServers: intPtr(10),
+	})
+	if err == nil {
+		t.Fatal("expected an error when max_spare_servers exceeds max_children, got nil")
+	}
+}
+
+func TestResolvePM_OnDemandSkipsDynamicConstraints(t *testing.T) {
+	got, err := ResolvePM(nil, &PMConfig{
+		Mode:               PMModeOnDemand,
+		MaxChildren:        intPtr(5),
+		ProcessIdleTimeout: "30s",
+	})
+	if err != nil {
+		t.Fatalf("ResolvePM returned error: %v", err)
+	}
+
+	if !got.IsOnDemand() {
+		t.Errorf("IsOnDemand() = false, want true for mode %q", got.Mode)
+	}
+	if got.ProcessIdleTimeout != "30s" {
+		t.Errorf("ProcessIdleTimeout = %q, want %q", got.ProcessIdleTimeout, "30s")
+	}
+}
+
+func TestResolvePM_NormalisesMode(t *testing.T) {
+	got, err := ResolvePM(nil, &PMConfig{Mode: "  OnDemand  "})
+	if err != nil {
+		t.Fatalf("ResolvePM returned error: %v", err)
+	}
+	if got.Mode != PMModeOnDemand {
+		t.Errorf("Mode = %q, want %q", got.Mode, PMModeOnDemand)
+	}
+}
+
+func TestResolvePM_Invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		pm   *PMConfig
+	}{
+		{"unknown mode", &PMConfig{Mode: "adaptive"}},
+		{"zero max_children", &PMConfig{MaxChildren: intPtr(0)}},
+		{"negative max_children", &PMConfig{MaxChildren: intPtr(-1)}},
+		{"negative max_requests", &PMConfig{MaxRequests: intPtr(-5)}},
+		{
+			"min spare above max spare",
+			&PMConfig{MinSpareServers: intPtr(9), MaxSpareServers: intPtr(3), StartServers: intPtr(3)},
+		},
+		{
+			"start_servers outside spare range",
+			&PMConfig{StartServers: intPtr(20), MinSpareServers: intPtr(2), MaxSpareServers: intPtr(6)},
+		},
+		{
+			"bad idle timeout",
+			&PMConfig{Mode: PMModeOnDemand, ProcessIdleTimeout: "soon"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ResolvePM(nil, tt.pm); err == nil {
+				t.Errorf("ResolvePM(%+v) = nil error, want an error", tt.pm)
+			}
+		})
+	}
+}
+
+func TestResolvePM_ValidIdleTimeoutFormats(t *testing.T) {
+	for _, v := range []string{"10", "10s", "5m", "1h", "1d"} {
+		t.Run(v, func(t *testing.T) {
+			if _, err := ResolvePM(nil, &PMConfig{Mode: PMModeOnDemand, ProcessIdleTimeout: v}); err != nil {
+				t.Errorf("ProcessIdleTimeout %q should be valid, got: %v", v, err)
+			}
+		})
+	}
+}
+
+func TestMergePM_OverrideKeepsUnsetBaseFields(t *testing.T) {
+	base := &PMConfig{Mode: PMModeDynamic, MaxChildren: intPtr(30), MaxRequests: intPtr(500)}
+	override := &PMConfig{MaxChildren: intPtr(10)}
+
+	merged := mergePM(base, override)
+
+	if merged.Mode != PMModeDynamic {
+		t.Errorf("Mode = %q, want %q", merged.Mode, PMModeDynamic)
+	}
+	if *merged.MaxChildren != 10 {
+		t.Errorf("MaxChildren = %d, want 10", *merged.MaxChildren)
+	}
+	if *merged.MaxRequests != 500 {
+		t.Errorf("MaxRequests = %d, want 500", *merged.MaxRequests)
+	}
+}
+
+func TestMergePM_NilHandling(t *testing.T) {
+	if merged := mergePM(nil, nil); merged != nil {
+		t.Errorf("mergePM(nil, nil) = %+v, want nil", merged)
+	}
+
+	base := &PMConfig{MaxChildren: intPtr(7)}
+	if merged := mergePM(base, nil); merged == nil || *merged.MaxChildren != 7 {
+		t.Errorf("mergePM(base, nil) should preserve base, got %+v", merged)
+	}
+	if merged := mergePM(nil, base); merged == nil || *merged.MaxChildren != 7 {
+		t.Errorf("mergePM(nil, override) should use override, got %+v", merged)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -20,6 +20,7 @@ type Config struct {
 	Domains       []Domain           `yaml:"domains"`
 	PHP           string             `yaml:"php"`
 	PHPINI        map[string]string  `yaml:"php_ini,omitempty"`
+	PM            *PMConfig          `yaml:"pm,omitempty"`       // PHP-FPM process manager tuning
 	Isolated      bool               `yaml:"isolated,omitempty"` // Use dedicated PHP-FPM master for this project
 	Services      Services           `yaml:"services"`
 	Env           map[string]string  `yaml:"env,omitempty"`

--- a/internal/php/isolated.go
+++ b/internal/php/isolated.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 	"time"
 
+	"qoliber/magebox/internal/config"
 	"qoliber/magebox/internal/lib"
 	"qoliber/magebox/internal/platform"
 )
@@ -32,7 +33,12 @@ type IsolatedProject struct {
 	PIDPath     string            `json:"pid_path"`
 	ConfigPath  string            `json:"config_path"`
 	Settings    map[string]string `json:"settings"`
-	CreatedAt   time.Time         `json:"created_at"`
+	// PM holds the resolved process manager settings. Stored in the registry so
+	// StartAllIsolated regenerates the config identically without re-reading
+	// the project's .magebox.yaml. Nil entries (written by older versions) fall
+	// back to the built-in defaults.
+	PM        *config.ResolvedPM `json:"pm,omitempty"`
+	CreatedAt time.Time          `json:"created_at"`
 }
 
 // IsolatedRegistry manages the registry of isolated PHP-FPM projects
@@ -159,14 +165,17 @@ type IsolatedFPMConfig struct {
 	SocketPath      string
 	User            string
 	Group           string
+	PMMode          string
 	MaxChildren     int
 	StartServers    int
 	MinSpareServers int
 	MaxSpareServers int
 	MaxRequests     int
-	SystemSettings  map[string]string // PHP_INI_SYSTEM settings (opcache, preload, etc.)
-	PoolSettings    map[string]string // PHP_INI_PERDIR settings
-	Env             map[string]string
+	// ProcessIdleTimeout is rendered only when PMMode is "ondemand".
+	ProcessIdleTimeout string
+	SystemSettings     map[string]string // PHP_INI_SYSTEM settings (opcache, preload, etc.)
+	PoolSettings       map[string]string // PHP_INI_PERDIR settings
+	Env                map[string]string
 }
 
 // getIsolatedSocketPath returns the socket path for an isolated project
@@ -190,7 +199,9 @@ func (c *IsolatedFPMController) getIsolatedLogPath(projectName, phpVersion strin
 }
 
 // Enable enables isolation for a project
-func (c *IsolatedFPMController) Enable(projectName, projectPath, phpVersion string, systemSettings map[string]string) (*IsolatedProject, error) {
+//
+// pm may be nil, in which case the built-in process manager defaults are used.
+func (c *IsolatedFPMController) Enable(projectName, projectPath, phpVersion string, systemSettings map[string]string, pm *config.ResolvedPM) (*IsolatedProject, error) {
 	// Check if already isolated
 	existing, err := c.registry.Get(projectName)
 	if err != nil {
@@ -200,6 +211,7 @@ func (c *IsolatedFPMController) Enable(projectName, projectPath, phpVersion stri
 		// Update settings and restart
 		existing.Settings = systemSettings
 		existing.PHPVersion = phpVersion
+		existing.PM = pm
 		if err := c.Stop(projectName); err != nil {
 			return nil, fmt.Errorf("failed to stop existing isolated master: %w", err)
 		}
@@ -214,6 +226,7 @@ func (c *IsolatedFPMController) Enable(projectName, projectPath, phpVersion stri
 		PIDPath:     c.getIsolatedPIDPath(projectName, phpVersion),
 		ConfigPath:  c.getIsolatedConfigPath(projectName, phpVersion),
 		Settings:    systemSettings,
+		PM:          pm,
 		CreatedAt:   time.Now(),
 	}
 
@@ -283,23 +296,30 @@ func (c *IsolatedFPMController) generateConfig(project *IsolatedProject) error {
 	// Separate system vs pool settings
 	systemSettings, poolSettings := SeparateSettings(project.Settings)
 
+	pmSettings := config.DefaultResolvedPM()
+	if project.PM != nil {
+		pmSettings = *project.PM
+	}
+
 	cfg := IsolatedFPMConfig{
-		ProjectName:     project.ProjectName,
-		ProjectPath:     project.ProjectPath,
-		PHPVersion:      project.PHPVersion,
-		PIDPath:         project.PIDPath,
-		ErrorLogPath:    c.getIsolatedLogPath(project.ProjectName, project.PHPVersion),
-		SocketPath:      project.SocketPath,
-		User:            getCurrentUser(),
-		Group:           getCurrentGroup(),
-		MaxChildren:     50,
-		StartServers:    8,
-		MinSpareServers: 4,
-		MaxSpareServers: 12,
-		MaxRequests:     1000,
-		SystemSettings:  systemSettings,
-		PoolSettings:    poolSettings,
-		Env:             make(map[string]string),
+		ProjectName:        project.ProjectName,
+		ProjectPath:        project.ProjectPath,
+		PHPVersion:         project.PHPVersion,
+		PIDPath:            project.PIDPath,
+		ErrorLogPath:       c.getIsolatedLogPath(project.ProjectName, project.PHPVersion),
+		SocketPath:         project.SocketPath,
+		User:               getCurrentUser(),
+		Group:              getCurrentGroup(),
+		PMMode:             pmSettings.Mode,
+		MaxChildren:        pmSettings.MaxChildren,
+		StartServers:       pmSettings.StartServers,
+		MinSpareServers:    pmSettings.MinSpareServers,
+		MaxSpareServers:    pmSettings.MaxSpareServers,
+		MaxRequests:        pmSettings.MaxRequests,
+		ProcessIdleTimeout: pmSettings.ProcessIdleTimeout,
+		SystemSettings:     systemSettings,
+		PoolSettings:       poolSettings,
+		Env:                make(map[string]string),
 	}
 
 	// Load template

--- a/internal/php/isolated_test.go
+++ b/internal/php/isolated_test.go
@@ -226,7 +226,8 @@ func TestIsolatedFPMConfig_Template(t *testing.T) {
 		"error_log = {{.ErrorLogPath}}",
 		"[{{.ProjectName}}]",
 		"listen = {{.SocketPath}}",
-		"pm = dynamic",
+		"pm = {{.PMMode}}",
+		"pm.max_children = {{.MaxChildren}}",
 		"{{range $key, $value := .SystemSettings}}",
 		"{{range $key, $value := .PoolSettings}}",
 	}

--- a/internal/php/pool.go
+++ b/internal/php/pool.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"qoliber/magebox/internal/config"
 	"qoliber/magebox/internal/lib"
 	"qoliber/magebox/internal/platform"
 )
@@ -47,11 +48,13 @@ const (
 // - LogPath: Path to PHP-FPM error log (e.g., "~/.magebox/logs/php-fpm/mystore-error.log")
 // - User: System user running PHP-FPM (e.g., "jakub")
 // - Group: System group running PHP-FPM (e.g., "staff")
+// - PMMode: Process manager mode ("static", "dynamic" or "ondemand")
 // - MaxChildren: Maximum number of child processes
-// - StartServers: Number of child processes created on startup
-// - MinSpareServers: Minimum number of idle server processes
-// - MaxSpareServers: Maximum number of idle server processes
+// - StartServers: Number of child processes created on startup (dynamic only)
+// - MinSpareServers: Minimum number of idle server processes (dynamic only)
+// - MaxSpareServers: Maximum number of idle server processes (dynamic only)
 // - MaxRequests: Number of requests each child process should execute before respawning
+// - ProcessIdleTimeout: Idle worker lifetime before termination (ondemand only)
 // - Env: Map of environment variables to set (e.g., {"MAGE_MODE": "developer"})
 // - PHPINI: Map of PHP INI overrides (e.g., {"opcache.enable": "0"})
 
@@ -82,15 +85,18 @@ type PoolConfig struct {
 	LogPath         string
 	User            string
 	Group           string
+	PMMode          string
 	MaxChildren     int
 	StartServers    int
 	MinSpareServers int
 	MaxSpareServers int
 	MaxRequests     int
-	Env             map[string]string
-	PHPINI          map[string]string
-	HasMailpit      bool
-	SendmailPath    string
+	// ProcessIdleTimeout is rendered only when PMMode is "ondemand".
+	ProcessIdleTimeout string
+	Env                map[string]string
+	PHPINI             map[string]string
+	HasMailpit         bool
+	SendmailPath       string
 }
 
 // defaultPHPINI returns the default PHP INI settings for Magento
@@ -150,14 +156,18 @@ func (g *PoolGenerator) getVersionPoolsDir(phpVersion string) string {
 
 // Generate generates a PHP-FPM pool configuration for a project
 // This is a convenience wrapper around GenerateWithResult that discards the detailed result
-func (g *PoolGenerator) Generate(projectName, projectPath, phpVersion string, env map[string]string, phpIni map[string]string, hasMailpit bool) error {
-	_, err := g.GenerateWithResult(projectName, projectPath, phpVersion, env, phpIni, hasMailpit)
+//
+// pm may be nil, in which case the built-in process manager defaults are used.
+func (g *PoolGenerator) Generate(projectName, projectPath, phpVersion string, env map[string]string, phpIni map[string]string, hasMailpit bool, pm *config.ResolvedPM) error {
+	_, err := g.GenerateWithResult(projectName, projectPath, phpVersion, env, phpIni, hasMailpit, pm)
 	return err
 }
 
 // GenerateWithResult generates a PHP-FPM pool configuration and returns detailed results
 // including information about system INI settings and ownership changes
-func (g *PoolGenerator) GenerateWithResult(projectName, projectPath, phpVersion string, env map[string]string, phpIni map[string]string, hasMailpit bool) (*GenerateResult, error) {
+//
+// pm may be nil, in which case the built-in process manager defaults are used.
+func (g *PoolGenerator) GenerateWithResult(projectName, projectPath, phpVersion string, env map[string]string, phpIni map[string]string, hasMailpit bool, pm *config.ResolvedPM) (*GenerateResult, error) {
 	result := &GenerateResult{}
 
 	// Ensure version-specific pools directory exists
@@ -209,23 +219,30 @@ func (g *PoolGenerator) GenerateWithResult(projectName, projectPath, phpVersion 
 		result.SystemINIChanged = previousOwner != nil
 	}
 
+	pmSettings := config.DefaultResolvedPM()
+	if pm != nil {
+		pmSettings = *pm
+	}
+
 	cfg := PoolConfig{
-		ProjectName:     projectName,
-		ProjectPath:     projectPath,
-		PHPVersion:      phpVersion,
-		SocketPath:      g.GetSocketPath(projectName, phpVersion),
-		LogPath:         filepath.Join(logsDir, projectName+"-error.log"),
-		User:            getCurrentUser(),
-		Group:           getCurrentGroup(),
-		MaxChildren:     50,
-		StartServers:    8,
-		MinSpareServers: 4,
-		MaxSpareServers: 12,
-		MaxRequests:     1000,
-		Env:             env,
-		PHPINI:          poolSettings, // Only pool-level settings go in pool config
-		HasMailpit:      hasMailpit,
-		SendmailPath:    sendmailPath,
+		ProjectName:        projectName,
+		ProjectPath:        projectPath,
+		PHPVersion:         phpVersion,
+		SocketPath:         g.GetSocketPath(projectName, phpVersion),
+		LogPath:            filepath.Join(logsDir, projectName+"-error.log"),
+		User:               getCurrentUser(),
+		Group:              getCurrentGroup(),
+		PMMode:             pmSettings.Mode,
+		MaxChildren:        pmSettings.MaxChildren,
+		StartServers:       pmSettings.StartServers,
+		MinSpareServers:    pmSettings.MinSpareServers,
+		MaxSpareServers:    pmSettings.MaxSpareServers,
+		MaxRequests:        pmSettings.MaxRequests,
+		ProcessIdleTimeout: pmSettings.ProcessIdleTimeout,
+		Env:                env,
+		PHPINI:             poolSettings, // Only pool-level settings go in pool config
+		HasMailpit:         hasMailpit,
+		SendmailPath:       sendmailPath,
 	}
 
 	content, err := g.renderPool(cfg)

--- a/internal/php/pool_test.go
+++ b/internal/php/pool_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"text/template"
 
+	"qoliber/magebox/internal/config"
 	"qoliber/magebox/internal/platform"
 )
 
@@ -70,7 +71,7 @@ func TestPoolGenerator_Generate(t *testing.T) {
 
 	phpIni := map[string]string{}
 
-	err := g.Generate("mystore", "/tmp/mystore", "8.2", env, phpIni, false)
+	err := g.Generate("mystore", "/tmp/mystore", "8.2", env, phpIni, false, nil)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestPoolGenerator_Generate(t *testing.T) {
 func TestPoolGenerator_GenerateWithoutEnv(t *testing.T) {
 	g, _ := setupTestPoolGenerator(t)
 
-	err := g.Generate("mystore", "/tmp/mystore", "8.3", nil, nil, false)
+	err := g.Generate("mystore", "/tmp/mystore", "8.3", nil, nil, false, nil)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestPoolGenerator_Remove(t *testing.T) {
 	g, _ := setupTestPoolGenerator(t)
 
 	// Generate pool first
-	if err := g.Generate("mystore", "/tmp/mystore", "8.2", nil, nil, false); err != nil {
+	if err := g.Generate("mystore", "/tmp/mystore", "8.2", nil, nil, false, nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 
@@ -154,10 +155,10 @@ func TestPoolGenerator_ListPools(t *testing.T) {
 	g, _ := setupTestPoolGenerator(t)
 
 	// Create some pool files
-	if err := g.Generate("project1", "/tmp/project1", "8.2", nil, nil, false); err != nil {
+	if err := g.Generate("project1", "/tmp/project1", "8.2", nil, nil, false, nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
-	if err := g.Generate("project2", "/tmp/project2", "8.3", nil, nil, false); err != nil {
+	if err := g.Generate("project2", "/tmp/project2", "8.3", nil, nil, false, nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 
@@ -187,11 +188,131 @@ func TestPoolGenerator_GetIncludeDirective(t *testing.T) {
 	}
 }
 
+// generatePoolWithPM renders a pool for the given process manager settings and
+// returns the file contents.
+func generatePoolWithPM(t *testing.T, pm *config.ResolvedPM) string {
+	t.Helper()
+
+	g, _ := setupTestPoolGenerator(t)
+	if err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, nil, false, pm); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(g.PoolsDirForVersion("8.2"), "testproject.conf"))
+	if err != nil {
+		t.Fatalf("Failed to read pool file: %v", err)
+	}
+	return string(content)
+}
+
+func TestPoolConfig_CustomDynamicPM(t *testing.T) {
+	pm, err := config.ResolvePM(nil, &config.PMConfig{
+		MaxChildren:     ptr(12),
+		StartServers:    ptr(4),
+		MinSpareServers: ptr(2),
+		MaxSpareServers: ptr(6),
+		MaxRequests:     ptr(500),
+	})
+	if err != nil {
+		t.Fatalf("ResolvePM failed: %v", err)
+	}
+
+	content := generatePoolWithPM(t, &pm)
+
+	for _, want := range []string{
+		"pm = dynamic",
+		"pm.max_children = 12",
+		"pm.start_servers = 4",
+		"pm.min_spare_servers = 2",
+		"pm.max_spare_servers = 6",
+		"pm.max_requests = 500",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("Pool content should contain %q", want)
+		}
+	}
+}
+
+func TestPoolConfig_OnDemandOmitsSpareServers(t *testing.T) {
+	pm, err := config.ResolvePM(nil, &config.PMConfig{
+		Mode:               config.PMModeOnDemand,
+		MaxChildren:        ptr(10),
+		ProcessIdleTimeout: "30s",
+	})
+	if err != nil {
+		t.Fatalf("ResolvePM failed: %v", err)
+	}
+
+	content := generatePoolWithPM(t, &pm)
+
+	for _, want := range []string{
+		"pm = ondemand",
+		"pm.max_children = 10",
+		"pm.process_idle_timeout = 30s",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("Pool content should contain %q", want)
+		}
+	}
+
+	// Spare-server directives are invalid for ondemand and must not be emitted.
+	for _, unwanted := range []string{"pm.start_servers", "pm.min_spare_servers", "pm.max_spare_servers"} {
+		if strings.Contains(content, unwanted) {
+			t.Errorf("ondemand pool must not contain %q", unwanted)
+		}
+	}
+}
+
+func TestPoolConfig_StaticOmitsDynamicDirectives(t *testing.T) {
+	pm, err := config.ResolvePM(nil, &config.PMConfig{
+		Mode:        config.PMModeStatic,
+		MaxChildren: ptr(6),
+	})
+	if err != nil {
+		t.Fatalf("ResolvePM failed: %v", err)
+	}
+
+	content := generatePoolWithPM(t, &pm)
+
+	if !strings.Contains(content, "pm = static") {
+		t.Error("Pool content should contain \"pm = static\"")
+	}
+	if !strings.Contains(content, "pm.max_children = 6") {
+		t.Error("Pool content should contain \"pm.max_children = 6\"")
+	}
+	for _, unwanted := range []string{"pm.start_servers", "pm.min_spare_servers", "pm.max_spare_servers", "pm.process_idle_timeout"} {
+		if strings.Contains(content, unwanted) {
+			t.Errorf("static pool must not contain %q", unwanted)
+		}
+	}
+}
+
+// A nil pm argument must keep the historical defaults, so existing installs are
+// unaffected by the feature.
+func TestPoolConfig_NilPMUsesBuiltInDefaults(t *testing.T) {
+	content := generatePoolWithPM(t, nil)
+
+	for _, want := range []string{
+		"pm = dynamic",
+		"pm.max_children = 50",
+		"pm.start_servers = 8",
+		"pm.min_spare_servers = 4",
+		"pm.max_spare_servers = 12",
+		"pm.max_requests = 1000",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("Pool content should contain default %q", want)
+		}
+	}
+}
+
+func ptr(i int) *int { return &i }
+
 func TestPoolConfig_Defaults(t *testing.T) {
 	g, _ := setupTestPoolGenerator(t)
 
 	// Generate and read back to verify defaults
-	if err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, nil, false); err != nil {
+	if err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, nil, false, nil); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 
@@ -253,7 +374,8 @@ func TestPoolTemplateValidity(t *testing.T) {
 	expectedSections := []string{
 		"[{{.ProjectName}}]",
 		"listen = {{.SocketPath}}",
-		"pm = dynamic",
+		"pm = {{.PMMode}}",
+		"pm.max_children = {{.MaxChildren}}",
 		"php_admin_value[error_log] = {{.LogPath}}",
 		"{{range $key, $value := .PHPINI}}",
 		"{{range $key, $value := .Env}}",
@@ -352,7 +474,7 @@ func TestGenerate_WithPHPINI(t *testing.T) {
 		"display_errors": "On",
 	}
 
-	err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, phpIni, false)
+	err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, phpIni, false, nil)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
@@ -378,7 +500,7 @@ func TestGenerate_WithPHPINI(t *testing.T) {
 func TestGenerate_WithMailpit(t *testing.T) {
 	g, tmpDir := setupTestPoolGenerator(t)
 
-	err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, nil, true)
+	err := g.Generate("testproject", "/tmp/testproject", "8.2", nil, nil, true, nil)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}

--- a/internal/php/system_ini_test.go
+++ b/internal/php/system_ini_test.go
@@ -387,7 +387,7 @@ func TestPoolGeneratorWithSystemSettings(t *testing.T) {
 		"memory_limit":                "768M",
 	}
 
-	result, err := gen.GenerateWithResult("test-project", "/path/to/project", "8.3", nil, phpIni, false)
+	result, err := gen.GenerateWithResult("test-project", "/path/to/project", "8.3", nil, phpIni, false, nil)
 	if err != nil {
 		t.Fatalf("GenerateWithResult failed: %v", err)
 	}

--- a/internal/php/templates/isolated-fpm.conf.tmpl
+++ b/internal/php/templates/isolated-fpm.conf.tmpl
@@ -24,11 +24,16 @@ listen.owner = {{.User}}
 listen.group = {{.Group}}
 listen.mode = 0660
 
-pm = dynamic
+pm = {{.PMMode}}
 pm.max_children = {{.MaxChildren}}
+{{- if eq .PMMode "dynamic"}}
 pm.start_servers = {{.StartServers}}
 pm.min_spare_servers = {{.MinSpareServers}}
 pm.max_spare_servers = {{.MaxSpareServers}}
+{{- end}}
+{{- if eq .PMMode "ondemand"}}
+pm.process_idle_timeout = {{.ProcessIdleTimeout}}
+{{- end}}
 pm.max_requests = {{.MaxRequests}}
 
 catch_workers_output = yes

--- a/internal/php/templates/pool.conf.tmpl
+++ b/internal/php/templates/pool.conf.tmpl
@@ -5,7 +5,7 @@
 ;   Main config:  {{.ProjectPath}}/.magebox.yaml
 ;   Local config: {{.ProjectPath}}/.magebox.local.yaml
 ;
-; Modify php_ini in the above files, then run: mbox restart
+; Modify php_ini or pm in the above files, then run: mbox restart
 ; Or use: mbox php ini set <key> <value>
 
 [{{.ProjectName}}]
@@ -18,11 +18,16 @@ listen.owner = {{.User}}
 listen.group = {{.Group}}
 listen.mode = 0666
 
-pm = dynamic
+pm = {{.PMMode}}
 pm.max_children = {{.MaxChildren}}
+{{- if eq .PMMode "dynamic"}}
 pm.start_servers = {{.StartServers}}
 pm.min_spare_servers = {{.MinSpareServers}}
 pm.max_spare_servers = {{.MaxSpareServers}}
+{{- end}}
+{{- if eq .PMMode "ondemand"}}
+pm.process_idle_timeout = {{.ProcessIdleTimeout}}
+{{- end}}
 pm.max_requests = {{.MaxRequests}}
 
 pm.status_path = /status

--- a/internal/project/lifecycle.go
+++ b/internal/project/lifecycle.go
@@ -91,6 +91,12 @@ func (m *Manager) Start(projectPath string) (*StartResult, error) {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("SSL: %v", err))
 	}
 
+	// Resolve PHP-FPM process manager settings (project overrides global default)
+	pmSettings, err := m.resolvePM(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("PHP-FPM process manager: %w", err)
+	}
+
 	// Check if project uses isolated PHP-FPM master
 	isolatedController := php.NewIsolatedFPMController(m.platform)
 
@@ -105,7 +111,7 @@ func (m *Manager) Start(projectPath string) (*StartResult, error) {
 			settings["opcache.enable"] = "0"
 		}
 
-		_, err := isolatedController.Enable(cfg.Name, projectPath, cfg.PHP, settings)
+		_, err := isolatedController.Enable(cfg.Name, projectPath, cfg.PHP, settings, &pmSettings)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("isolated PHP-FPM: %w", err))
 		}
@@ -120,7 +126,7 @@ func (m *Manager) Start(projectPath string) (*StartResult, error) {
 
 		// Generate PHP-FPM pool (Mailpit always enabled for local dev safety)
 		// This prevents accidental emails to real addresses during development
-		poolResult, err := m.poolGenerator.GenerateWithResult(cfg.Name, projectPath, cfg.PHP, cfg.Env, cfg.PHPINI, true)
+		poolResult, err := m.poolGenerator.GenerateWithResult(cfg.Name, projectPath, cfg.PHP, cfg.Env, cfg.PHPINI, true, &pmSettings)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("PHP-FPM pool: %w", err))
 		} else if poolResult != nil {
@@ -660,6 +666,17 @@ php: "%s"
 	return os.WriteFile(configPath, []byte(content), 0644)
 }
 
+// resolvePM combines the machine-wide default process manager settings with
+// the project's own `pm` block. A missing or unreadable global config is not
+// fatal: the project config alone still resolves against the built-in defaults.
+func (m *Manager) resolvePM(cfg *config.Config) (config.ResolvedPM, error) {
+	var globalPM *config.PMConfig
+	if globalCfg, err := config.LoadGlobalConfig(m.platform.HomeDir); err == nil && globalCfg != nil {
+		globalPM = globalCfg.DefaultPM
+	}
+	return config.ResolvePM(globalPM, cfg.PM)
+}
+
 // RegenerateConfigs regenerates PHP-FPM pool and Nginx vhost configs
 // without restarting services (useful for applying config changes)
 func (m *Manager) RegenerateConfigs(projectPath string) error {
@@ -668,8 +685,13 @@ func (m *Manager) RegenerateConfigs(projectPath string) error {
 		return err
 	}
 
+	pmSettings, err := m.resolvePM(cfg)
+	if err != nil {
+		return fmt.Errorf("PHP-FPM process manager: %w", err)
+	}
+
 	// Regenerate PHP-FPM pool
-	if err := m.poolGenerator.Generate(cfg.Name, projectPath, cfg.PHP, cfg.Env, cfg.PHPINI, true); err != nil {
+	if err := m.poolGenerator.Generate(cfg.Name, projectPath, cfg.PHP, cfg.Env, cfg.PHPINI, true, &pmSettings); err != nil {
 		return fmt.Errorf("failed to regenerate PHP-FPM pool: %w", err)
 	}
 

--- a/lib/templates/php/pool.conf.tmpl
+++ b/lib/templates/php/pool.conf.tmpl
@@ -5,7 +5,7 @@
 ;   Main config:  {{.ProjectPath}}/.magebox.yaml
 ;   Local config: {{.ProjectPath}}/.magebox.local.yaml
 ;
-; Modify php_ini in the above files, then run: mbox restart
+; Modify php_ini or pm in the above files, then run: mbox restart
 ; Or use: mbox php ini set <key> <value>
 
 [{{.ProjectName}}]
@@ -18,11 +18,16 @@ listen.owner = {{.User}}
 listen.group = {{.Group}}
 listen.mode = 0666
 
-pm = dynamic
+pm = {{.PMMode}}
 pm.max_children = {{.MaxChildren}}
+{{- if eq .PMMode "dynamic"}}
 pm.start_servers = {{.StartServers}}
 pm.min_spare_servers = {{.MinSpareServers}}
 pm.max_spare_servers = {{.MaxSpareServers}}
+{{- end}}
+{{- if eq .PMMode "ondemand"}}
+pm.process_idle_timeout = {{.ProcessIdleTimeout}}
+{{- end}}
 pm.max_requests = {{.MaxRequests}}
 
 pm.status_path = /status

--- a/vitepress/reference/config-options.md
+++ b/vitepress/reference/config-options.md
@@ -202,6 +202,49 @@ Most settings can also be managed through `magebox php ini set <key> <value>`, w
 
 ---
 
+### pm
+
+`object`
+
+PHP-FPM process manager tuning for this project's pool. Every key is optional; anything you leave out falls back to the global `default_pm` and then to the built-in default.
+
+```yaml
+pm:
+  mode: ondemand           # static | dynamic | ondemand
+  max_children: 12
+  process_idle_timeout: 30s
+```
+
+| Option | Type | Default | Applies to | Description |
+|--------|------|---------|------------|-------------|
+| `mode` | string | `dynamic` | all | Process manager: `static`, `dynamic` or `ondemand` |
+| `max_children` | int | `50` | all | Maximum number of worker processes |
+| `max_requests` | int | `1000` | all | Requests a worker handles before respawning (`0` disables) |
+| `start_servers` | int | `8` | `dynamic` | Workers created at startup |
+| `min_spare_servers` | int | `4` | `dynamic` | Minimum idle workers |
+| `max_spare_servers` | int | `12` | `dynamic` | Maximum idle workers |
+| `process_idle_timeout` | string | `10s` | `ondemand` | Idle worker lifetime before termination |
+
+#### Choosing a mode
+
+* **`dynamic`** (default) keeps a pool of idle workers warm and scales up under load. Good for the project you are actively working on.
+* **`ondemand`** starts no workers until a request arrives and reaps them after `process_idle_timeout`. Useful when a machine hosts many projects: the ones you are not using cost nothing.
+* **`static`** keeps exactly `max_children` workers alive at all times. Predictable, but reserves the memory whether you use it or not.
+
+#### Sizing max_children
+
+The default of `50` assumes a pool has the machine to itself. When several projects run side by side, their peaks can collectively oversubscribe the host: PHP-FPM will happily start more workers than there are CPU cores, and each active Magento worker can hold hundreds of megabytes.
+
+Since throughput is bounded by cores rather than workers, a value close to your core count is usually enough for local development. Requests beyond that queue on the socket instead of competing for memory.
+
+::: warning
+PHP-FPM refuses to start the entire master process when one pool is malformed, which would take down every project sharing that PHP version. MageBox therefore validates these values before writing the pool file — `min_spare_servers` must not exceed `max_spare_servers`, `max_spare_servers` must not exceed `max_children`, and `start_servers` must fall between the two.
+
+If you only lower `max_children`, MageBox scales the untouched spare-server defaults down to fit rather than erroring.
+:::
+
+---
+
 ### commands
 
 `object`
@@ -315,6 +358,22 @@ Default PHP version for new projects.
 ```yaml
 default_php: "8.3"
 ```
+
+---
+
+### default_pm
+
+`object`
+
+Machine-wide PHP-FPM process manager baseline, applied to every project that does not set its own [`pm`](#pm) block. Accepts the same keys.
+
+```yaml
+default_pm:
+  mode: ondemand
+  max_children: 12
+```
+
+This is the place to size PHP-FPM for the host rather than per project. A project's own `pm` block overrides it key by key, so a single project can still run `dynamic` while the rest stay `ondemand`.
 
 ---
 
@@ -507,4 +566,8 @@ tld: test
 portainer: false
 editor: code
 auto_start: true
+
+default_pm:
+  mode: ondemand
+  max_children: 12
 ```

--- a/vitepress/services/php-fpm.md
+++ b/vitepress/services/php-fpm.md
@@ -60,10 +60,10 @@ listen.mode = 0666
 
 pm = dynamic
 pm.max_children = 50
-pm.start_servers = 5
-pm.min_spare_servers = 2
-pm.max_spare_servers = 10
-pm.max_requests = 500
+pm.start_servers = 8
+pm.min_spare_servers = 4
+pm.max_spare_servers = 12
+pm.max_requests = 1000
 
 ; Error logging
 php_admin_value[error_log] = ~/.magebox/logs/php-fpm/mystore.log
@@ -83,6 +83,45 @@ php_admin_value[opcache.max_accelerated_files] = 130986
 ; Environment variables
 env[MAGE_MODE] = developer
 ```
+
+### Process Manager
+
+The `pm.*` directives above are the defaults. Override them per project with a `pm` block in `.magebox.yaml` or `.magebox.local.yaml`:
+
+```yaml
+pm:
+  mode: dynamic          # static | dynamic | ondemand
+  max_children: 12
+  start_servers: 4
+  min_spare_servers: 2
+  max_spare_servers: 6
+  max_requests: 1000
+```
+
+Only the keys relevant to the chosen mode are written to the pool file — `ondemand` emits `pm.process_idle_timeout` instead of the spare-server directives, and `static` emits neither.
+
+#### Running many projects on one machine
+
+Each pool defaults to `pm.max_children = 50`, sized as if it were the only project on the host. With a handful of projects started at once, their peaks can collectively demand far more memory and CPU than the machine has — PHP-FPM starts workers well past the core count, and each active Magento worker can hold hundreds of megabytes.
+
+Idle pools are cheap (a waiting worker holds very little), so the cost shows up during bursts rather than at rest. Two ways to bound it:
+
+```yaml
+# ~/.magebox/config.yaml — applies to every project
+default_pm:
+  mode: ondemand
+  max_children: 12
+```
+
+`ondemand` starts no workers until a request arrives and reaps them after `process_idle_timeout`, so dormant projects cost nothing. Alternatively keep `dynamic` and simply lower `max_children` — throughput is bounded by CPU cores, so a value near your core count loses nothing while keeping bursts from swapping the machine.
+
+A project's own `pm` block overrides the global default key by key, so the project you are actively working on can stay `dynamic` while the rest run `ondemand`.
+
+::: warning
+A malformed pool prevents the PHP-FPM master from starting, which affects every project on that PHP version. MageBox validates the values before writing the pool file and reports the problem instead.
+:::
+
+See [Configuration Options](/reference/config-options#pm) for the full list of keys.
 
 ## PHP Version Management
 


### PR DESCRIPTION
## Problem

Pool configs hardcode `pm = dynamic` with `pm.max_children = 50`, sized as if each pool had the machine to itself. With several projects started, the defaults oversubscribe the host — on my 10-core setup, 8 pools meant 400 potential workers, and one Magento page load in developer mode spiked a pool to 46 active workers and the load average to 78.

There is no way to tune it: the values are literals in `pool.go` / `isolated.go`, and a hand-edited pool file is overwritten on the next `magebox start`.

## Solution

A `pm` block in `.magebox.yaml` / `.magebox.local.yaml`, plus a `default_pm` baseline in `~/.magebox/config.yaml`:

```yaml
pm:
  mode: ondemand           # static | dynamic | ondemand
  max_children: 12
  process_idle_timeout: 30s
```

Precedence is project > global > built-in, merged key by key. `ondemand` is the useful addition for multi-project machines: dormant projects start no workers at all.

Keys: `mode`, `max_children`, `max_requests` (all modes), `start_servers`, `min_spare_servers`, `max_spare_servers` (dynamic), `process_idle_timeout` (ondemand). Only the directives valid for the selected mode are rendered.

## Validation

Values are checked before the pool file is written, mirroring PHP-FPM's own startup constraints — one malformed pool stops the FPM master, taking down every project on that PHP version. Lowering only `max_children` scales the untouched spare-server defaults down to fit rather than erroring; explicitly-set values are never rewritten.

## Compatibility

Defaults unchanged — without a `pm` block, pool files render byte-identical. The new argument on `Generate`/`GenerateWithResult`/`Enable` is nullable. Isolated masters persist resolved settings in the registry; older entries fall back to defaults.

Also corrects `vitepress/services/php-fpm.md`, which documented `5/2/10/500` while the code generates `8/4/12/1000`. `CHANGELOG.md` untouched, as it appears to be maintained in release commits.

## Testing

New tests for precedence, merging, the scaling rule, each validation constraint, and pool rendering per mode (including that `nil` still yields the historical defaults). `go test ./...`, `go vet ./...` and `golangci-lint run ./...` clean.
