### PR TITLE
Skip PR artifact comment job on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
   comment-artifacts:
     name: Comment PR with artifact links
     needs: build
-    if: github.event_name == 'pull_request'
+    # Skip on fork PRs: GITHUB_TOKEN is read-only there, so commenting always 403s.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The `Comment PR with artifact links` job fails on every PR from a fork with `403 Resource not accessible by integration`. It asks for `pull-requests: write`, but GitHub caps `GITHUB_TOKEN` to read-only for `pull_request` runs from a fork — requesting the permission cannot override that. The run goes red even though all builds, tests and lint pass.

It's not flaky: always fails for fork PRs, never for PRs from branches in this repo. Since most PRs here come from `qoliber` branches, it just looks intermittent. Introduced in 1fe4817 — #111 was green from a fork the day before; #123 (external contributor), #128 and #133 all failed on this job since.

The fix gates the job on the PR coming from this repo:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

On `push` events `github.event.pull_request` is null, so the job is still skipped — this covers the old `github.event_name == 'pull_request'` guard.

This PR is itself from a fork, so green CI here *is* the proof it works.

Trade-off: fork PRs lose the artifact-links comment (today they never get it anyway). The real fix is a `workflow_run` trigger, which runs with a writable token — left out because it only takes effect after merge and can't demonstrate itself in a PR. Happy to open that separately.
