### PR TITLE
Self-heal outdated port forwarding daemon on `magebox start`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,23 +78,27 @@ PHP-FPM and Nginx run natively — no virtualization overhead, no bind mount iss
 
 MageBox manages complexity so the developer doesn't have to. PHP versions, SSL certificates, DNS, port forwarding — everything is configured automatically. The same applies to tooling MageBox integrates with: the correct version is automatically selected based on the project configuration.
 
-**3. Don't duplicate what already exists**
+**3. Self-healing by default**
 
-MageBox doesn't build its own version of functionality that existing tools already handle well. If magerun2 already supports database operations, MageBox integrates with it rather than rebuilding it. Features in core must provide real added value over what's already available — such as a progress bar for imports, or automatic version detection.
+Every part of the environment MageBox manages is expected to detect and repair its own broken or outdated state — a stopped service container, an inactive port forwarding daemon, a stale system component after an upgrade. Repair happens at the next natural moment (such as `magebox start` or first use), without the user having to know a fix exists. Error messages that instruct the user are a fallback for when automatic repair is impossible (e.g. no TTY for sudo), never the design. Detection must check actual behaviour (does the port accept connections?), not configuration presence (does the file exist?). When adding or changing a feature, ask: what happens when this breaks — and can it fix itself?
 
-**4. Core is for everyone, specific is for you**
-
-Functionality in MageBox core must be valuable to the broad Magento community. Workflow-specific tooling — things that fit how your team works but aren't universal — belongs in custom commands (`.magebox.yaml`) or is shared via the team server. The custom commands system and `.magebox.local.yaml` override mechanism are deliberately designed to enable this without bloating core.
-
-**5. Pragmatic, not speculative**
-
-MageBox adds support for tools and technologies when there is actual adoption in the Magento ecosystem. Potentially interesting but not yet widely adopted technologies are not preemptively supported.
-
-**6. One config, the whole team**
+**4. One config, the whole team**
 
 Project configuration lives in `.magebox.yaml` in the repository. Personal preferences in `.magebox.local.yaml`. Team-wide settings, repositories, and assets via the team server. This means a new developer can get started with `magebox clone` + `magebox start` — no manual setup required.
 
-**7. Magento-first, framework-open**
+**5. Don't duplicate what already exists**
+
+MageBox doesn't build its own version of functionality that existing tools already handle well. If magerun2 already supports database operations, MageBox integrates with it rather than rebuilding it. Features in core must provide real added value over what's already available — such as a progress bar for imports, or automatic version detection.
+
+**6. Core is for everyone, specific is for you**
+
+Functionality in MageBox core must be valuable to the broad Magento community. Workflow-specific tooling — things that fit how your team works but aren't universal — belongs in custom commands (`.magebox.yaml`) or is shared via the team server. The custom commands system and `.magebox.local.yaml` override mechanism are deliberately designed to enable this without bloating core.
+
+**7. Pragmatic, not speculative**
+
+MageBox adds support for tools and technologies when there is actual adoption in the Magento ecosystem. Potentially interesting but not yet widely adopted technologies are not preemptively supported.
+
+**8. Magento-first, framework-open**
 
 MageBox is built for Magento 2 and MageOS, but the architecture is open to other PHP frameworks in the future. The Magento-specific experience is not sacrificed for generality.
 

--- a/cmd/magebox/bootstrap.go
+++ b/cmd/magebox/bootstrap.go
@@ -605,7 +605,7 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 		if err := pfMgr.Setup(); err != nil {
 			fmt.Println(cli.Error("failed"))
 			cli.PrintWarning("Port forwarding setup failed: %v", err)
-			cli.PrintWarning("Run 'magebox bootstrap' again or check: sudo launchctl list com.magebox.portforward")
+			cli.PrintWarning("Run 'magebox bootstrap' again or try: sudo launchctl kickstart -k system/com.magebox.portforward")
 			errors = append(errors, "Port forwarding setup failed")
 		} else {
 			fmt.Println(cli.Success("done"))

--- a/internal/portforward/pf.go
+++ b/internal/portforward/pf.go
@@ -40,6 +40,40 @@ func NewManager() *Manager {
 // This ensures existing users get updates when they run bootstrap
 const launchDaemonVersion = "7"
 
+// daemonAction describes what EnsureRulesActive must do to get port
+// forwarding into a working, up-to-date state.
+type daemonAction int
+
+const (
+	actionNone daemonAction = iota
+	actionBootstrapRequired
+	actionUpgrade
+	actionKickstart
+)
+
+// nextAction decides how to reconcile the daemon state. An outdated daemon is
+// upgraded even when it is active, so binary upgrades take effect without the
+// user having to run bootstrap manually.
+func nextAction(installed, outdated, active bool) daemonAction {
+	switch {
+	case !installed:
+		return actionBootstrapRequired
+	case outdated:
+		return actionUpgrade
+	case !active:
+		return actionKickstart
+	default:
+		return actionNone
+	}
+}
+
+// plistOutdated reports whether the installed plist content is missing the
+// current version marker.
+func plistOutdated(content []byte) bool {
+	marker := fmt.Sprintf("MageBox-Version-%s", launchDaemonVersion)
+	return !strings.Contains(string(content), marker)
+}
+
 // findMageboxBinary returns the path to the magebox binary for use in the LaunchDaemon
 func findMageboxBinary() string {
 	// Check common installation paths
@@ -61,28 +95,36 @@ func findMageboxBinary() string {
 	return "/usr/local/bin/magebox"
 }
 
-// EnsureRulesActive checks if port forwarding is active and starts the daemon
-// if needed. This is a lightweight operation safe to call on every
-// "magebox start" so that reboots and sleep/wake cycles are self-healing.
-// Returns true if forwarding was already active, false if it had to be restored.
+// EnsureRulesActive checks if port forwarding is active and up to date, and
+// self-heals when it is not: an outdated daemon (left behind by a binary
+// upgrade) is reinstalled, an inactive one is kickstarted. This is a
+// lightweight operation safe to call on every "magebox start" so that
+// reboots, sleep/wake cycles, and upgrades are self-healing.
+// Returns true if forwarding was already active and current, false if it had
+// to be restored.
 func (m *Manager) EnsureRulesActive() (bool, error) {
 	if m.platform != "darwin" {
 		return true, nil // Not applicable on Linux
 	}
 
-	if !m.IsInstalled() {
-		return false, fmt.Errorf("port forwarding not configured — run 'magebox bootstrap' first")
-	}
-
-	if m.AreRulesActive() {
+	switch nextAction(m.IsInstalled(), m.needsUpgrade(), m.AreRulesActive()) {
+	case actionNone:
 		return true, nil
-	}
 
-	verbose.Debug("Port forwarding daemon not active, restarting...")
+	case actionBootstrapRequired:
+		return false, fmt.Errorf("port forwarding not configured — run 'magebox bootstrap' first")
 
-	// Try to kickstart the daemon
-	if err := m.kickstartDaemon(); err != nil {
-		return false, fmt.Errorf("failed to restart port forwarding daemon: %w", err)
+	case actionUpgrade:
+		verbose.Debug("Port forwarding daemon outdated, upgrading...")
+		if err := m.Setup(); err != nil {
+			return false, fmt.Errorf("failed to upgrade port forwarding daemon — run 'magebox bootstrap': %w", err)
+		}
+
+	default: // actionKickstart
+		verbose.Debug("Port forwarding daemon not active, restarting...")
+		if err := m.kickstartDaemon(); err != nil {
+			return false, fmt.Errorf("failed to restart port forwarding daemon: %w", err)
+		}
 	}
 
 	// Wait briefly for the daemon to start listening
@@ -94,7 +136,7 @@ func (m *Manager) EnsureRulesActive() (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("port forwarding daemon not responding — check: sudo launchctl list %s", launchDaemonLabel)
+	return false, fmt.Errorf("port forwarding daemon not responding — try: sudo launchctl kickstart -k system/%s, or run 'magebox bootstrap'", launchDaemonLabel)
 }
 
 // Setup installs the port forwarding LaunchDaemon
@@ -152,8 +194,7 @@ func (m *Manager) needsUpgrade() bool {
 		return true
 	}
 
-	versionMarker := fmt.Sprintf("MageBox-Version-%s", launchDaemonVersion)
-	if !strings.Contains(string(content), versionMarker) {
+	if plistOutdated(content) {
 		verbose.Debug("LaunchDaemon missing version %s marker", launchDaemonVersion)
 		return true
 	}

--- a/internal/portforward/pf_test.go
+++ b/internal/portforward/pf_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) qoliber
+// Author: Jakub Winkler <jwinkler@qoliber.com>
+
+package portforward
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNextAction(t *testing.T) {
+	tests := []struct {
+		name      string
+		installed bool
+		outdated  bool
+		active    bool
+		want      daemonAction
+	}{
+		{
+			name:      "not installed requires bootstrap",
+			installed: false,
+			want:      actionBootstrapRequired,
+		},
+		{
+			name:      "outdated daemon is upgraded even when active",
+			installed: true,
+			outdated:  true,
+			active:    true,
+			want:      actionUpgrade,
+		},
+		{
+			name:      "outdated and inactive daemon is upgraded",
+			installed: true,
+			outdated:  true,
+			active:    false,
+			want:      actionUpgrade,
+		},
+		{
+			name:      "current but inactive daemon is kickstarted",
+			installed: true,
+			outdated:  false,
+			active:    false,
+			want:      actionKickstart,
+		},
+		{
+			name:      "current and active daemon needs nothing",
+			installed: true,
+			outdated:  false,
+			active:    true,
+			want:      actionNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nextAction(tt.installed, tt.outdated, tt.active)
+			if got != tt.want {
+				t.Errorf("nextAction(%v, %v, %v) = %v, want %v", tt.installed, tt.outdated, tt.active, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlistOutdated(t *testing.T) {
+	current := fmt.Sprintf("<!-- MageBox-Version-%s -->\n<plist></plist>", launchDaemonVersion)
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "current version marker is up to date",
+			content: current,
+			want:    false,
+		},
+		{
+			name:    "old version marker is outdated",
+			content: "<!-- MageBox-Version-4 -->\n<plist></plist>",
+			want:    true,
+		},
+		{
+			name:    "missing marker is outdated",
+			content: "<plist></plist>",
+			want:    true,
+		},
+		{
+			name:    "empty content is outdated",
+			content: "",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := plistOutdated([]byte(tt.content)); got != tt.want {
+				t.Errorf("plistOutdated(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}

--- a/vitepress/guide/faq.md
+++ b/vitepress/guide/faq.md
@@ -220,11 +220,17 @@ On macOS, only root can bind to ports below 1024 (like 80 and 443). Port forward
 
 ### Port forwarding stops working after sleep/restart
 
-This was fixed in v1.0.2! Run `magebox bootstrap` to upgrade your LaunchDaemon with the new sleep/wake recovery mechanism.
+`magebox start` checks on every run whether port forwarding actually works and repairs it automatically — it restarts the daemon if it's not responding, and reinstalls it if it's outdated (for example after a MageBox upgrade). If it still fails, run:
+
+```bash
+sudo launchctl kickstart -k system/com.magebox.portforward
+```
+
+or run `magebox bootstrap` to reinstall the daemon from scratch.
 
 ### I'm using Little Snitch/firewall software
 
-Some firewalls reset pf rules. MageBox's LaunchDaemon automatically restores rules every 30 seconds. If issues persist, whitelist `/etc/pf.anchors/com.magebox`.
+Port forwarding runs as a small TCP proxy (`magebox _portforward`) managed by a LaunchDaemon — it does not use pf firewall rules. If your firewall blocks local connections to ports 80/443, allow the `magebox` binary.
 
 ### Composer patches hang during `composer install`
 


### PR DESCRIPTION
## Problem

A binary upgrade (Homebrew or `selfupdate`) only replaces the binary — the installed LaunchDaemon is only upgraded by `magebox bootstrap`. Users who never re-run bootstrap silently keep running an old daemon generation, including the removed pf-based approach.

## Changes

- `EnsureRulesActive()` now reconciles the daemon state on every `magebox start`: outdated daemon → reinstall via `Setup()`, inactive → kickstart, missing → bootstrap hint. Decision logic extracted into a pure `nextAction()` with table-driven tests.
- Replaced the `sudo launchctl list` hint (shows the job even when it does nothing) with the `launchctl kickstart` command that actually restarts it.
- Updated FAQ entries that still described the removed pf anchor mechanism.
- Added **"Self-healing by default"** as a core principle to CLAUDE.md: every part of the environment MageBox manages is expected to detect and repair its own broken or outdated state at the next natural moment — instructing the user is the fallback, never the design. Codifies the pattern from #128.
- Reordered the principles into logical groups: architecture → developer experience → team → scope → positioning.

Follows the same approach as #128.

https://claude.ai/code/session_011EJ9p83uoE4YLhrnuMqcmb