### PR TITLE
Fix CI lint failure: remove deprecated PreferServerCipherSuites

### DIFF
--- a/internal/teamserver/server.go
+++ b/internal/teamserver/server.go
@@ -1779,8 +1779,7 @@ func (s *Server) Start() error {
 	if s.config.TLS.Enabled {
 		// Configure TLS
 		tlsConfig := &tls.Config{
-			MinVersion:               tls.VersionTLS12,
-			PreferServerCipherSuites: true,
+			MinVersion: tls.VersionTLS12,
 			CipherSuites: []uint16{
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,


### PR DESCRIPTION
CI's golangci-lint-action now pulls golangci-lint 2.13, which flags `(crypto/tls.Config).PreferServerCipherSuites` as SA1019 (deprecated and ignored since Go 1.18). This fails the Lint job on every PR against main. Removing the field is behavior-neutral.