### PR TITLE
Free ports 80/443 on `magebox global stop` (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to MageBox will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`magebox global stop` Did Not Free Ports 80/443 on macOS** - `global stop` stopped Nginx and the Docker services but left the port forwarding LaunchDaemon (`com.magebox.portforward`) loaded, so ports 80 and 443 stayed occupied and other local dev tools failed to bind them. `magebox global stop` now unloads the daemon and waits until port 80 is actually released; `magebox global start` loads it again. The plist stays installed, so no `magebox bootstrap` is needed to get forwarding back, and `magebox global status` now reports the port forwarding state on macOS. ([#108](https://github.com/qoliber/magebox/issues/108))
+
 ## [2.0.1] - 2026-09-01
 
 ### Added

--- a/cmd/magebox/global.go
+++ b/cmd/magebox/global.go
@@ -12,6 +12,7 @@ import (
 	"qoliber/magebox/internal/nginx"
 	"qoliber/magebox/internal/php"
 	"qoliber/magebox/internal/platform"
+	"qoliber/magebox/internal/portforward"
 )
 
 var globalCmd = &cobra.Command{
@@ -73,6 +74,18 @@ func runGlobalStart(cmd *cobra.Command, args []string) error {
 		fmt.Println(cli.Error("failed: " + err.Error()))
 	} else {
 		fmt.Println(cli.Success("started"))
+	}
+
+	// Restore port forwarding (macOS) — "magebox global stop" hands 80/443
+	// back to the system, so they have to be reclaimed here.
+	pfManager := portforward.NewManager()
+	if pfManager.IsSupported() {
+		fmt.Print("  Port forwarding... ")
+		if err := pfManager.Start(); err != nil {
+			fmt.Println(cli.Error("failed: " + err.Error()))
+		} else {
+			fmt.Println(cli.Success("active"))
+		}
 	}
 
 	// Start Docker services
@@ -143,6 +156,18 @@ func runGlobalStop(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Unload the port forwarding daemon (macOS) so ports 80 and 443 are
+	// released — otherwise other local tools cannot bind them.
+	pfManager := portforward.NewManager()
+	if pfManager.IsSupported() {
+		fmt.Print("  Port forwarding... ")
+		if err := pfManager.Stop(); err != nil {
+			fmt.Printf("failed: %v\n", err)
+		} else {
+			fmt.Println("stopped")
+		}
+	}
+
 	fmt.Println("\nGlobal services stopped!")
 	return nil
 }
@@ -171,6 +196,11 @@ func runGlobalStatus(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %-20s %s\n", "Docker", cli.StatusInstalled(false))
 	} else {
 		fmt.Printf("  %-20s %s\n", "Docker", cli.Status(dockerRunning))
+	}
+
+	// Check port forwarding (macOS only)
+	if pfManager := portforward.NewManager(); pfManager.IsSupported() {
+		fmt.Printf("  %-20s %s\n", "Port forwarding", cli.Status(pfManager.AreRulesActive()))
 	}
 
 	// Check mkcert

--- a/internal/portforward/pf.go
+++ b/internal/portforward/pf.go
@@ -22,6 +22,10 @@ const (
 	// Legacy pf files — cleaned up during upgrade
 	legacyPfRulesFile    = "/etc/pf.anchors/com.magebox"
 	legacyPfHelperScript = "/usr/local/bin/magebox-pf-restore"
+
+	// How long to wait for the daemon to start or stop listening
+	daemonWaitAttempts = 10
+	daemonWaitDelay    = 200 * time.Millisecond
 )
 
 // Manager handles port forwarding setup
@@ -122,21 +126,86 @@ func (m *Manager) EnsureRulesActive() (bool, error) {
 
 	default: // actionKickstart
 		verbose.Debug("Port forwarding daemon not active, restarting...")
-		if err := m.kickstartDaemon(); err != nil {
+		if err := m.startDaemon(); err != nil {
 			return false, fmt.Errorf("failed to restart port forwarding daemon: %w", err)
 		}
 	}
 
 	// Wait briefly for the daemon to start listening
-	for i := 0; i < 10; i++ {
-		time.Sleep(200 * time.Millisecond)
-		if m.AreRulesActive() {
-			verbose.Debug("Port forwarding daemon started successfully")
-			return false, nil
-		}
+	if waitFor(m.AreRulesActive, daemonWaitAttempts, daemonWaitDelay) {
+		verbose.Debug("Port forwarding daemon started successfully")
+		return false, nil
 	}
 
 	return false, fmt.Errorf("port forwarding daemon not responding — try: sudo launchctl kickstart -k system/%s, or run 'magebox bootstrap'", launchDaemonLabel)
+}
+
+// IsSupported reports whether port forwarding is managed on this platform.
+// Only macOS needs it — on Linux Nginx binds 80/443 directly.
+func (m *Manager) IsSupported() bool {
+	return m.platform == "darwin"
+}
+
+// Start loads the port forwarding daemon and waits until it accepts
+// connections. Used by "magebox global start" to hand the web ports back to
+// MageBox after a "magebox global stop".
+func (m *Manager) Start() error {
+	if !m.IsSupported() {
+		return nil
+	}
+	if !m.IsInstalled() {
+		return fmt.Errorf("port forwarding not configured — run 'magebox bootstrap' first")
+	}
+	if m.AreRulesActive() {
+		return nil
+	}
+
+	if err := m.startDaemon(); err != nil {
+		return fmt.Errorf("failed to start port forwarding daemon: %w", err)
+	}
+	if !waitFor(m.AreRulesActive, daemonWaitAttempts, daemonWaitDelay) {
+		return fmt.Errorf("port forwarding daemon not responding — run 'magebox bootstrap'")
+	}
+	return nil
+}
+
+// Stop unloads the port forwarding daemon so ports 80 and 443 are released
+// back to the system. The plist is left in place, so "magebox global start"
+// (and the next reboot) bring forwarding back without a bootstrap.
+func (m *Manager) Stop() error {
+	if !m.IsSupported() || !m.IsInstalled() {
+		return nil
+	}
+	if !m.AreRulesActive() && !m.isDaemonLoaded() {
+		return nil
+	}
+
+	if err := m.unloadLaunchDaemon(); err != nil {
+		return fmt.Errorf("failed to unload port forwarding daemon: %w", err)
+	}
+	if !waitFor(func() bool { return !m.AreRulesActive() }, daemonWaitAttempts, daemonWaitDelay) {
+		return fmt.Errorf("port 80 is still in use after unloading the daemon — another service may be listening")
+	}
+	return nil
+}
+
+// startDaemon loads the daemon, or restarts it when launchd already knows it.
+func (m *Manager) startDaemon() error {
+	if m.isDaemonLoaded() {
+		return m.kickstartDaemon()
+	}
+	return m.loadLaunchDaemon()
+}
+
+// waitFor polls cond until it reports true, giving up after attempts tries.
+func waitFor(cond func() bool, attempts int, delay time.Duration) bool {
+	for i := 0; i < attempts; i++ {
+		time.Sleep(delay)
+		if cond() {
+			return true
+		}
+	}
+	return false
 }
 
 // Setup installs the port forwarding LaunchDaemon
@@ -154,7 +223,7 @@ func (m *Manager) Setup() error {
 		verbose.Debug("Port forwarding daemon already installed and up to date")
 		// Make sure it's running
 		if !m.AreRulesActive() {
-			_ = m.kickstartDaemon()
+			_ = m.startDaemon()
 		}
 		return nil
 	}

--- a/internal/portforward/pf_test.go
+++ b/internal/portforward/pf_test.go
@@ -6,6 +6,7 @@ package portforward
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestNextAction(t *testing.T) {
@@ -97,5 +98,67 @@ func TestPlistOutdated(t *testing.T) {
 				t.Errorf("plistOutdated(%q) = %v, want %v", tt.content, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWaitFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		trueAfter int // number of polls before cond reports true
+		attempts  int
+		want      bool
+	}{
+		{"true on first poll", 1, 3, true},
+		{"true on last poll", 3, 3, true},
+		{"never true", 99, 3, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			cond := func() bool {
+				calls++
+				return calls >= tt.trueAfter
+			}
+
+			if got := waitFor(cond, tt.attempts, time.Millisecond); got != tt.want {
+				t.Errorf("waitFor() = %v, want %v", got, tt.want)
+			}
+			if calls > tt.attempts {
+				t.Errorf("cond polled %d times, want at most %d", calls, tt.attempts)
+			}
+		})
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{"darwin", true},
+		{"linux", false},
+		{"windows", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			m := &Manager{platform: tt.platform}
+			if got := m.IsSupported(); got != tt.want {
+				t.Errorf("IsSupported() on %s = %v, want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+// Start and Stop must be no-ops on Linux, where Nginx binds 80/443 directly.
+func TestStartStopNoOpOnLinux(t *testing.T) {
+	m := &Manager{platform: "linux"}
+
+	if err := m.Start(); err != nil {
+		t.Errorf("Start() on linux = %v, want nil", err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Errorf("Stop() on linux = %v, want nil", err)
 	}
 }

--- a/vitepress/reference/commands.md
+++ b/vitepress/reference/commands.md
@@ -1286,6 +1286,8 @@ magebox global start
 
 Starts Nginx and Docker services.
 
+On macOS it also loads the port forwarding LaunchDaemon again, so ports 80 and 443 are forwarded to Nginx (8080/8443) after a previous `magebox global stop`.
+
 ---
 
 ### `magebox global stop`
@@ -1297,6 +1299,8 @@ magebox global stop
 ```
 
 Stops all Docker containers and Nginx.
+
+On macOS it additionally unloads the port forwarding LaunchDaemon (`com.magebox.portforward`), releasing ports 80 and 443 so other local tools can bind them. The daemon itself stays installed — `magebox global start` (or a reboot) brings forwarding back without running `magebox bootstrap` again.
 
 ---
 


### PR DESCRIPTION
Fixes #108.

`magebox global stop` stopped Nginx and the Docker services but left the port forwarding LaunchDaemon (`com.magebox.portforward`) loaded, so ports 80 and 443 stayed occupied and other local dev tools could not bind them.

**Changes**
- `global stop` unloads the daemon and waits until port 80 is actually released.
- `global start` loads it again (falls back to `kickstart` when launchd already knows the service).
- `global status` shows the port forwarding state on macOS.
- The plist stays installed, so forwarding comes back without running `magebox bootstrap`; a reboot restores it too.
- macOS-only — on Linux all three are no-ops.

Tests cover the new `waitFor` poll helper, `IsSupported`, and the Linux no-op paths. `make lint` and `make test` pass. Not verified end-to-end on macOS (needs sudo/launchctl) — @LouisdeLooze could you check?